### PR TITLE
feat: externalize `peerDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Code splitting is enabled by default and supported in `cjs` and `esm` format.
 
 ### Excluding packages
 
-By default tsup bundles all `import`-ed modules but `dependencies` in your `packages.json` are always excluded, you can also use `--external <module>` flag to mark other packages as external.
+By default tsup bundles all `import`-ed modules but `dependencies` and `peerDependencies` in your `packages.json` are always excluded, you can also use `--external <module>` flag to mark other packages as external.
 
 ### Generate declaration file
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,10 @@ export function loadTsConfig(cwd: string) {
 export async function getDeps(cwd: string) {
   const data = await loadPkg(cwd)
 
-  const deps = Object.keys(data.dependencies || {})
+  const deps = Array.from(new Set([
+    ...Object.keys(data.dependencies || {}),
+    ...Object.keys(data.peerDependencies || {})
+  ]))
 
   return deps
 }


### PR DESCRIPTION
This PR will auto externalize `peerDependencies` as the same as `dependencies`. For most of the cases, it makes sense for libraries to not bundle their `peerDependencies`.