### PR TITLE
feat: add `--onSuccess <command>` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "postcss-load-config": "^3.0.1",
     "resolve-from": "^5.0.0",
     "rollup": "^2.41.2",
-    "string-argv": "^0.3.1",
     "sucrase": "^3.17.1"
   },
   "devDependencies": {
@@ -49,8 +48,9 @@
     "postcss": "^8.2.8",
     "postcss-simple-vars": "^6.0.3",
     "prettier": "^2.2.1",
-    "rollup-plugin-hashbang": "^2.2.2",
     "rollup-plugin-dts": "^2.0.1",
+    "rollup-plugin-hashbang": "^2.2.2",
+    "string-argv": "^0.3.1",
     "strip-json-comments": "^3.1.1",
     "svelte": "3.35.0",
     "ts-essentials": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "esbuild": "^0.9.2",
+    "execa": "^5.0.0",
     "globby": "^11.0.2",
     "joycon": "^2.2.5",
     "postcss-load-config": "^3.0.1",
     "resolve-from": "^5.0.0",
     "rollup": "^2.41.2",
+    "string-argv": "^0.3.1",
     "sucrase": "^3.17.1"
   },
   "devDependencies": {
@@ -41,7 +43,6 @@
     "@types/node": "^14.14.35",
     "@types/resolve": "^1.20.0",
     "buble": "^0.20.0",
-    "execa": "^5.0.0",
     "fs-extra": "^9.1.0",
     "jest": "^26.6.3",
     "jju": "^1.4.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,10 @@ async function main() {
     .option('--dts-resolve', 'Resolve externals types used for d.ts files')
     .option('--sourcemap', 'Generate sourcemap file')
     .option('--watch', 'Watch mode')
+    .option(
+      '--onSuccess <command>',
+      'Execute command after successful build, specially useful for watch mode'
+    )
     .option('--env.* <value>', 'Define compile-time env variables')
     .option('--define.* <value>', 'Define compile-time constants')
     .option('--external <name>', 'Mark specific packages as external')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -495,3 +495,18 @@ test('bundle svelte', async () => {
     "
   `)
 })
+
+test('onSuccess', async () => {
+  const randomNumber = Math.random() + ''
+  const { logs } = await run(
+    getTestName(),
+    {
+      'input.ts': "console.log('test');",
+    },
+    {
+      flags: ['--onSuccess', 'echo ' + randomNumber],
+    }
+  )
+
+  expect(logs.includes(randomNumber)).toBe(true)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3801,6 +3801,11 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-length@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.1.tgz#4a973bf31ef77c4edbceadd6af2611996985f8a1"


### PR DESCRIPTION
I was thinking that tsup is a good alternative to [tsc-watch](https://github.com/gilamran/tsc-watch) while using watch mode, but it definitely needed at least the "onSuccess", maybe more lifecycles could be added after