### PR TITLE
fix watch catch error, earlier prev process kill

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { cac } from 'cac'
-import { handlError } from './errors'
+import { handleError } from './errors'
 import { Format, Options } from './'
 
 function ensureArray(input: string): string[] {
@@ -98,4 +98,4 @@ async function main() {
   await cli.runMatchedCommand()
 }
 
-main().catch(handlError)
+main().catch(handleError)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,7 +13,7 @@ export class PrettyError extends Error {
   }
 }
 
-export function handlError(error: any) {
+export function handleError(error: any) {
   if (error.loc) {
     console.error(
       colors.bold(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from './utils'
 import { FSWatcher } from 'chokidar'
 import glob from 'globby'
-import { PrettyError } from './errors'
+import { PrettyError, handleError } from './errors'
 import { postcssPlugin } from './esbuild/postcss'
 import { externalPlugin } from './esbuild/external'
 import { sveltePlugin } from './esbuild/svelte'
@@ -344,7 +344,7 @@ export async function build(_options: Options) {
           ignoreInitial: true,
         }
       ).on('all', async () => {
-        await buildAll().catch(console.error)
+        await buildAll().catch(handleError)
       })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,13 +344,15 @@ export async function build(_options: Options) {
           ignoreInitial: true,
         }
       ).on('all', async () => {
-        await buildAll()
+        await buildAll().catch(console.error)
       })
   }
 
   let existingOnSuccess: ChildProcess | undefined
 
   const buildAll = async () => {
+    if (existingOnSuccess) existingOnSuccess.kill()
+
     if (options.clean) {
       await removeFiles(['**/*', '!**/*.d.ts'], options.outDir)
       console.log(makeLabel('CLI', 'info'), `Cleaning output folder`)
@@ -363,8 +365,6 @@ export async function build(_options: Options) {
       ),
     ])
     if (options.onSuccess) {
-      if (existingOnSuccess) existingOnSuccess.kill()
-
       const parts = parseArgsStringToArgv(options.onSuccess)
       const exec = parts[0]
       const args = parts.splice(1)

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -4,7 +4,7 @@ import { makeLabel, NormalizedOptions } from './'
 import dtsPlugin from 'rollup-plugin-dts'
 import hashbangPlugin from 'rollup-plugin-hashbang'
 import jsonPlugin from '@rollup/plugin-json'
-import { handlError } from './errors'
+import { handleError } from './errors'
 import { getDeps, removeFiles } from './utils'
 import { TsResolveOptions, tsResolvePlugin } from './rollup/ts-resolve'
 
@@ -89,7 +89,7 @@ async function runRollup(options: RollupConfig) {
     )
   } catch (error) {
     console.log(`${makeLabel('dts', 'error')} Build error`)
-    handlError(error)
+    handleError(error)
   }
 }
 
@@ -115,7 +115,7 @@ async function watchRollup(options: {
       )
     } else if (event.code === 'ERROR') {
       console.log(`${makeLabel('dts', 'error')} Build error`)
-      handlError(event.error)
+      handleError(event.error)
     }
   })
 }


### PR DESCRIPTION
While playing with it I realized two thing:

- If a build error happens on watch-mode, the process is killed because the promise is not being catched
- It's better to kill the previous onSuccess process as early as possible to give the OS more time to kill the process for the new process to not overlap