### PR TITLE
add ignoreWatch & docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,24 @@ When an entry file like `src/cli.ts` contains hashbang like `#!/bin/env node` ts
 tsup src/index.ts --watch
 ```
 
+You can specify one or more extra folders to ignore watching changes
+
+> By default it always ignores `dist`, `node_modules` & `.git`
+
+```bash
+tsup src/index.ts --watch --ignore-watch ignore-this-folder
+```
+
+> You can specify more than a folder repeating "--ignore-watch", for example: `tsup src src/index.ts --watch --ignore-watch folder1 --ignore-watch folder2`
+
+### onSuccess
+
+You can specify command to be executed after a successful build, specially useful for **Watch mode**
+
+```
+tsup src/index.ts --watch --onSuccess "node dist/index.js"
+```
+
 ### Minify output
 
 You can also minify the output, resulting into lower bundle sizes by using the `--minify` flag.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ async function main() {
     .option('--dts-resolve', 'Resolve externals types used for d.ts files')
     .option('--sourcemap', 'Generate sourcemap file')
     .option('--watch', 'Watch mode')
+    .option('--ignore-watch <path>', 'Ignore custom paths in watch mode')
     .option(
       '--onSuccess <command>',
       'Execute command after successful build, specially useful for watch mode'

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type Options = {
   minifySyntax?: boolean
   keepNames?: boolean
   watch?: boolean
+  ignoreWatch?: string[] | string
   onSuccess?: string
   jsxFactory?: string
   jsxFragment?: string
@@ -367,10 +368,17 @@ export async function build(_options: Options) {
     if (!options.watch) return
 
     const { watch } = await import('chokidar')
+
+    const customIgnores = options.ignoreWatch
+      ? Array.isArray(options.ignoreWatch)
+        ? options.ignoreWatch
+        : [options.ignoreWatch]
+      : []
+
     const watcher = watch('.', {
       ignoreInitial: true,
       ignorePermissionErrors: true,
-      ignored: ['**/{.git,node_modules}/**', options.outDir],
+      ignored: ['**/{.git,node_modules}/**', options.outDir, ...customIgnores],
     })
     watcher.on('all', async (type, file) => {
       console.log(makeLabel('CLI', 'info'), `Change detected: ${type} ${file}`)


### PR DESCRIPTION
Added **--ignore-watch,** since after changing the watching, in a project with runtime code-generation it basically breaks because of not being able to ignore them.

And added some docs about --ignore-watch & onSuccess