### PR TITLE
use tree-kill

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "postcss-load-config": "^3.0.1",
     "resolve-from": "^5.0.0",
     "rollup": "^2.45.2",
-    "sucrase": "^3.18.1"
+    "sucrase": "^3.18.1",
+    "tree-kill": "^1.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ specifiers:
   strip-json-comments: ^3.1.1
   sucrase: ^3.18.1
   svelte: 3.37.0
+  tree-kill: ^1.2.2
   ts-essentials: ^7.0.1
   ts-jest: ^26.5.5
   typescript: ^4.2.4
@@ -53,6 +54,7 @@ dependencies:
   resolve-from: 5.0.0
   rollup: 2.45.2
   sucrase: 3.18.1
+  tree-kill: 1.2.2
 
 devDependencies:
   '@babel/core': 7.13.15
@@ -3956,6 +3958,11 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
+
+  /tree-kill/1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: false
 
   /ts-essentials/7.0.1_typescript@4.2.4:
     resolution: {integrity: sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { parseArgsStringToArgv } from 'string-argv'
 import type { ChildProcess } from 'child_process'
 import execa from 'execa'
 import consola from 'consola'
+import kill from 'tree-kill'
 import { version } from '../package.json'
 import { log, setSilent } from './log'
 
@@ -297,30 +298,12 @@ export async function runEsbuild(
 const killProcess = ({
   pid,
   signal = 'SIGTERM',
-  timeout = 5000,
 }: {
   pid: number
   signal?: string | number
-  timeout?: number
 }) =>
-  new Promise<void>((resolve, reject) => {
-    try {
-      process.kill(pid, signal)
-    } catch (err) {
-      return resolve()
-    }
-    let count = 0
-    setInterval(() => {
-      try {
-        process.kill(pid, 0)
-      } catch (err) {
-        // the process does not exists anymore
-        resolve()
-      }
-      if ((count += 50) > timeout) {
-        reject(new Error('Timeout process kill'))
-      }
-    }, 50)
+  new Promise<unknown>((resolve) => {
+    kill(pid, signal, resolve)
   })
 
 const normalizeOptions = async (


### PR DESCRIPTION
while using it in Windows I realized the previous killing process is unreliable, in MacOS it was fine, but windows was the issue.

[tree-kill](https://www.npmjs.com/package/tree-kill) doesn't have any dependency, and doing a global require shouldn't have any impact, but using a dynamic import is possible