### PR TITLE
Improve file config load & add docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,67 @@ tsup-node src/index.ts
 
 All other CLI flags still apply to this command.
 
+### Using custom configuration
+
+You can also use `tsup` using file configurations or in a property inside your `package.json`, and you can even use `TypeScript` and have type-safety while you are using it.
+
+> Most of these options can be overwritten using the CLI options
+
+You can use any of these files:
+
+- `tsup.config.ts`
+- `tsup.config.js`
+- `tsup.config.cjs`
+- `tsup.config.json`
+- `tsup` property in your `package.json`
+
+> In all the custom files you can export the options either as `tsup`, `default` or `module.exports =` 
+
+#### TypeScript
+
+```ts
+// tsup.config.ts
+import type { Options } from 'tsup'
+export const tsup: Options = {
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  entryPoints: ['src/index.ts'],
+}
+```
+
+#### JavaScript
+
+```js
+// tsup.config.cjs
+/**
+ * @type {import("tsup").Options}
+ */
+module.exports = {
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  entryPoints: ['src/index.ts'],
+}
+```
+
+#### package.json
+
+```json
+{
+  "tsup": {
+    "splitting": false,
+    "sourcemap": true,
+    "clean": true,
+    "entryPoints": ["src/index.ts"]
+  },
+  "scripts": {
+    "build": "tsup"
+  }
+}
+```
+
+
 ### Generate declaration file
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,12 @@ import {
 } from 'esbuild'
 import type { MarkRequired, Buildable } from 'ts-essentials'
 import {
-  getDeps,
-  loadTsConfig,
-  loadPkg,
   getBabel,
-  loadTsupConfig,
   removeFiles,
   rewriteImportMetaUrl,
   debouncePromise,
 } from './utils'
+import { getDeps, loadTsConfig, loadPkg, loadTsupConfig } from './load'
 import glob from 'globby'
 import { handleError, PrettyError } from './errors'
 import { postcssPlugin } from './esbuild/postcss'

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,0 +1,106 @@
+import fs from 'fs'
+import { parse as parseJson } from 'jju/lib/parse'
+import JoyCon from 'joycon'
+import path from 'path'
+import stripJsonComments from 'strip-json-comments'
+import { transform } from 'sucrase'
+
+import { requireFromString } from './require-from-string'
+
+const joycon = new JoyCon()
+
+const configJoycon = new JoyCon({
+  packageKey: 'tsup',
+})
+
+const jsonLoader = {
+  test: /\.json$/,
+  async load(filepath: string) {
+    try {
+      const content = stripJsonComments(
+        await fs.promises.readFile(filepath, 'utf8')
+      )
+      return parseJson(content)
+    } catch (error) {
+      throw new Error(
+        `Failed to parse ${path.relative(process.cwd(), filepath)}: ${
+          error.message
+        }`
+      )
+    }
+  },
+}
+
+joycon.addLoader(jsonLoader)
+configJoycon.addLoader(jsonLoader)
+
+const tsLoader = {
+  test: /\.ts$/,
+  async load(filepath: string) {
+    const content = await fs.promises.readFile(filepath, 'utf8')
+    const { code } = transform(content, {
+      filePath: filepath,
+      transforms: ['imports', 'typescript'],
+    })
+    const mod = requireFromString(code, filepath)
+    return mod.default || mod
+  },
+}
+
+joycon.addLoader(tsLoader)
+configJoycon.addLoader(tsLoader)
+
+const cjsLoader = {
+  test: /\.cjs$/,
+  load(filepath: string) {
+    delete require.cache[filepath]
+    return require(filepath)
+  },
+}
+
+joycon.addLoader(cjsLoader)
+configJoycon.addLoader(cjsLoader)
+
+export function loadTsConfig(cwd: string) {
+  return joycon.load(
+    ['tsconfig.build.json', 'tsconfig.json'],
+    cwd,
+    path.dirname(cwd)
+  )
+}
+
+export async function loadTsupConfig(cwd: string) {
+  const config = await configJoycon.load(
+    [
+      'tsup.config.ts',
+      'tsup.config.js',
+      'tsup.config.cjs',
+      'tsup.config.json',
+      'package.json',
+    ],
+    cwd,
+    path.dirname(cwd)
+  )
+
+  if (config.data && config.data.tsup) config.data = config.data.tsup
+
+  return config
+}
+
+export async function loadPkg(cwd: string) {
+  const { data } = await joycon.load(['package.json'], cwd, path.dirname(cwd))
+  return data || {}
+}
+
+export async function getDeps(cwd: string) {
+  const data = await loadPkg(cwd)
+
+  const deps = Array.from(
+    new Set([
+      ...Object.keys(data.dependencies || {}),
+      ...Object.keys(data.peerDependencies || {}),
+    ])
+  )
+
+  return deps
+}

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -4,9 +4,10 @@ import { NormalizedOptions } from './'
 import hashbangPlugin from 'rollup-plugin-hashbang'
 import jsonPlugin from '@rollup/plugin-json'
 import { handleError } from './errors'
-import { getDeps, removeFiles, loadTsConfig } from './utils'
+import { removeFiles } from './utils'
 import { TsResolveOptions, tsResolvePlugin } from './rollup/ts-resolve'
 import { log, setSilent } from './log'
+import { getDeps, loadTsConfig } from './load'
 
 // Use `require` to esbuild use the cjs build of rollup-plugin-dts
 // the mjs build of rollup-plugin-dts uses `import.meta.url` which makes Node throws syntax error


### PR DESCRIPTION
- I separated the load logic into its own module since I don't think they are not just utils
- Added support for using a `tsup` property inside the `package.json`
  - While implementing it I figured out that using a possible "tsup" export from the file is also useful, since it enables a one-line export with `export const tsup: Options = `, or using `exports.tsup =` in plain js.
- Added docs about this feature


closes #300 