### PR TITLE
respect silent config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,19 +363,19 @@ const normalizeOptions = async (
 }
 
 export async function build(_options: Options) {
-  setSilent(_options.silent)
+  const config = await loadTsupConfig(process.cwd())
+
+  const options = await normalizeOptions(config.data, _options)
+
+  setSilent(options.silent)
 
   log('CLI', 'info', `tsup v${version}`)
-
-  const config = await loadTsupConfig(process.cwd())
 
   if (config.path) {
     log('CLI', 'info', `Using tsup config: ${config.path}`)
   }
 
-  const options = await normalizeOptions(config.data, _options)
-
-  if (_options.watch) {
+  if (options.watch) {
     log('CLI', 'info', 'Running in watch mode')
   }
 


### PR DESCRIPTION
Right now the `silent` config is ignored since the `setSilent` is called before the config resolution, this is a small fix for that