### PR TITLE
fix: call setSilent earlier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,8 @@ const normalizeOptions = async (
     ...optionsOverride,
   }
 
+  setSilent(options.silent)
+
   const input = options.entryPoints
   if (input) {
     options.entryPoints = await glob(input)
@@ -366,8 +368,6 @@ export async function build(_options: Options) {
   const config = await loadTsupConfig(process.cwd())
 
   const options = await normalizeOptions(config.data, _options)
-
-  setSilent(options.silent)
 
   log('CLI', 'info', `tsup v${version}`)
 


### PR DESCRIPTION
I realized that the `setSilent` is being called a little later than it should, and it's missing a couple of logs to be silenced:

![image](https://user-images.githubusercontent.com/8672915/120056982-d6748380-c00d-11eb-8a2b-248dd0a795d7.png)
