### PR TITLE
fix: drop cjs_shims if they are not used

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -86,9 +86,6 @@ test('simple', async () => {
       default: () => input_default
     });
 
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
     // foo.ts
     var foo_default = \\"foo\\";
 
@@ -296,11 +293,6 @@ test('es5 target', async () => {
     __export(exports, {
       Foo: function () { return Foo; }
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var Foo = /*@__PURE__*/(function () {
       function Foo () {}
 
@@ -350,11 +342,6 @@ test('multiple formats', async () => {
     __export(exports, {
       a: () => a
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var a = 1;
     // Annotate the CommonJS export names for ESM import in node:
     0 && (module.exports = {
@@ -429,11 +416,6 @@ test('multiple formats with legacy output', async () => {
     __export(exports, {
       a: () => a
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var a = 1;
     // Annotate the CommonJS export names for ESM import in node:
     0 && (module.exports = {
@@ -466,7 +448,7 @@ test('minify', async () => {
   )
 
   expect(output).toMatchInlineSnapshot(`
-    "var t=Object.defineProperty;var o=e=>t(e,\\"__esModule\\",{value:!0});var c=(e,r)=>{o(e);for(var n in r)t(e,n,{get:r[n],enumerable:!0})};c(exports,{foo:()=>i});var u=typeof document==\\"undefined\\"?new(require(\\"url\\")).URL(\\"file:\\"+__filename).href:document.currentScript&&document.currentScript.src||new URL(\\"main.js\\",document.baseURI).href;function i(){return\\"foo\\"}0&&(module.exports={foo});
+    "var r=Object.defineProperty;var t=o=>r(o,\\"__esModule\\",{value:!0});var e=(o,f)=>{t(o);for(var n in f)r(o,n,{get:f[n],enumerable:!0})};e(exports,{foo:()=>u});function u(){return\\"foo\\"}0&&(module.exports={foo});
     "
   `)
   expect(outFiles).toMatchInlineSnapshot(`
@@ -502,11 +484,6 @@ test('--env flag', async () => {
     __export(exports, {
       env: () => env
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var env = \\"production\\";
     // Annotate the CommonJS export names for ESM import in node:
     0 && (module.exports = {
@@ -540,11 +517,7 @@ test('import css', async () => {
     `,
   })
 
-  expect(output).toMatchInlineSnapshot(`
-    "// ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-    "
-  `)
+  expect(output).toMatchInlineSnapshot(`""`)
   expect(outFiles).toMatchInlineSnapshot(`
     Array [
       "input.css",
@@ -569,11 +542,7 @@ test('import css in --dts', async () => {
     { flags: ['--dts'] }
   )
 
-  expect(output).toMatchInlineSnapshot(`
-    "// ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-    "
-  `)
+  expect(output).toMatchInlineSnapshot(`""`)
   expect(outFiles).toMatchInlineSnapshot(`
     Array [
       "input.css",
@@ -632,11 +601,6 @@ test('external', async () => {
       baz: () => baz,
       foo: () => import_foo.foo
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var import_foo = __toModule(require(\\"foo\\"));
     var import_bar = __toModule(require(\\"bar\\"));
 
@@ -663,10 +627,7 @@ test('disable code splitting to get proper module.exports =', async () => {
     }
   )
   expect(output).toMatchInlineSnapshot(`
-    "// ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
+    "// input.ts
     module.exports = 123;
     "
   `)
@@ -725,9 +686,6 @@ test('bundle svelte', async () => {
     __export(exports, {
       App: () => App_default
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
 
     // App.svelte
     var import_internal = __toModule(require(\\"svelte/internal\\"));
@@ -814,9 +772,6 @@ test('support baseUrl and paths in tsconfig.json', async () => {
     __export(exports, {
       foo: () => foo
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
 
     // foo.ts
     var foo = \\"foo\\";
@@ -984,11 +939,6 @@ test('exclude dependencies', async () => {
       foo: () => import_foo.foo,
       nested: () => import_nested.nested
     });
-
-    // ../../../assets/cjs_shims.js
-    var importMetaUrlShim = typeof document === \\"undefined\\" ? new (require(\\"url\\")).URL(\\"file:\\" + __filename).href : document.currentScript && document.currentScript.src || new URL(\\"main.js\\", document.baseURI).href;
-
-    // input.ts
     var import_foo = __toModule(require(\\"foo\\"));
     var import_nested = __toModule(require(\\"foo/nested\\"));
     // Annotate the CommonJS export names for ESM import in node:
@@ -1014,10 +964,10 @@ test('code splitting in cjs format', async () => {
     "\\"use strict\\";Object.defineProperty(exports, \\"__esModule\\", {value: true});
 
 
-    var _chunkNPFUVKWZjs = require('./chunk-NPFUVKWZ.js');
+    var _chunkNVG2ND5Pjs = require('./chunk-NVG2ND5P.js');
 
     // input.ts
-    var foo = () => Promise.resolve().then(() => _chunkNPFUVKWZjs.__toModule.call(void 0, _chunkNPFUVKWZjs.__require.call(void 0, \\"./foo-6WE36XGR.js\\")));
+    var foo = () => Promise.resolve().then(() => _chunkNVG2ND5Pjs.__toModule.call(void 0, _chunkNVG2ND5Pjs.__require.call(void 0, \\"./foo-M66RVMRJ.js\\")));
 
 
     exports.foo = foo;
@@ -1027,10 +977,10 @@ test('code splitting in cjs format', async () => {
     "\\"use strict\\";Object.defineProperty(exports, \\"__esModule\\", {value: true});
 
 
-    var _chunkNPFUVKWZjs = require('./chunk-NPFUVKWZ.js');
+    var _chunkNVG2ND5Pjs = require('./chunk-NVG2ND5P.js');
 
     // another-input.ts
-    var foo = () => Promise.resolve().then(() => _chunkNPFUVKWZjs.__toModule.call(void 0, _chunkNPFUVKWZjs.__require.call(void 0, \\"./foo-6WE36XGR.js\\")));
+    var foo = () => Promise.resolve().then(() => _chunkNVG2ND5Pjs.__toModule.call(void 0, _chunkNVG2ND5Pjs.__require.call(void 0, \\"./foo-M66RVMRJ.js\\")));
 
 
     exports.foo = foo;


### PR DESCRIPTION
closes #410

Use `"sideEffects": false` in `assets` to drop the injected `importMetaUrlShim` if it is not needed.