### PR TITLE
feat(minor): support `node:` import in older node versions

### DIFF
--- a/src/esbuild/external.ts
+++ b/src/esbuild/external.ts
@@ -6,18 +6,14 @@ const NON_NODE_MODULE_RE = /^[^.\/]|^\.[^.\/]|^\.\.[^\/]/
 export const externalPlugin = ({
   patterns,
   skipNodeModulesBundle,
-  disabled,
 }: {
   patterns?: (string | RegExp)[]
   skipNodeModulesBundle?: boolean
-  disabled?: boolean
 }): Plugin => {
   return {
     name: `external`,
 
     setup(build) {
-      if (disabled) return
-
       if (skipNodeModulesBundle) {
         build.onResolve({ filter: NON_NODE_MODULE_RE }, (args) => ({
           path: args.path,

--- a/src/esbuild/node-protocol.ts
+++ b/src/esbuild/node-protocol.ts
@@ -1,0 +1,21 @@
+import { Plugin } from 'esbuild'
+
+/**
+ * The node: protocol was added to require in Node v14.18.0
+ * https://nodejs.org/api/esm.html#node-imports
+ */
+export const nodeProtocolPlugin = (): Plugin => {
+	const nodeProtocol = 'node:'
+
+	return {
+		name: 'node-protocol-plugin',
+		setup({ onResolve }) {
+			onResolve({
+				filter: /^node:/,
+			}, ({ path }) => ({
+				path: path.slice(nodeProtocol.length),
+				external: true
+			}))
+		}
+	}
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -556,6 +556,37 @@ test('import css in --dts', async () => {
   `)
 })
 
+test('node protocol', async () => {
+  const { output } = await run(getTestName(), {
+    'input.ts': `import fs from 'node:fs'; console.log(fs)`,
+  })
+  expect(output).toMatchInlineSnapshot(`
+    "var __create = Object.create;
+    var __defProp = Object.defineProperty;
+    var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+    var __getOwnPropNames = Object.getOwnPropertyNames;
+    var __getProtoOf = Object.getPrototypeOf;
+    var __hasOwnProp = Object.prototype.hasOwnProperty;
+    var __markAsModule = (target) => __defProp(target, \\"__esModule\\", { value: true });
+    var __reExport = (target, module2, desc) => {
+      if (module2 && typeof module2 === \\"object\\" || typeof module2 === \\"function\\") {
+        for (let key of __getOwnPropNames(module2))
+          if (!__hasOwnProp.call(target, key) && key !== \\"default\\")
+            __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
+      }
+      return target;
+    };
+    var __toModule = (module2) => {
+      return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, \\"default\\", module2 && module2.__esModule && \\"default\\" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
+    };
+
+    // input.ts
+    var import_node_fs = __toModule(require(\\"fs\\"));
+    console.log(import_node_fs.default);
+    "
+  `)
+})
+
 test('external', async () => {
   const { output } = await run(getTestName(), {
     'input.ts': `export {foo} from 'foo'


### PR DESCRIPTION
## Problem
Bundling a dependency with `import fs from 'node:fs'` didn't work with Node v12 because it would convert the import statement to a `require`, which requires Node v14.18.0.

## Changes
- Add a simple esbuild plugin to strip the `node:` protocol
- Remove the `disabled` option in `externalPlugin` in favor of not passing it into esbuild in the first place. Minor performance nitpick since I didn't want to have two different ways of disabling plugins.