### PR TITLE
fix: only use esm shim for node platform

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -172,7 +172,7 @@ export async function runEsbuild(
       },
       inject: [
         format === 'cjs' ? path.join(__dirname, '../assets/cjs_shims.js') : '',
-        format === 'esm' ? path.join(__dirname, '../assets/esm_shims.js') : '',
+        format === 'esm' && platform === 'node' ? path.join(__dirname, '../assets/esm_shims.js') : '',
         ...(options.inject || []),
       ].filter(Boolean),
       outdir:


### PR DESCRIPTION
Maybe we can use [deno_std](https://github.com/denoland/deno_std) to make shim work in both node and browser.

file url to path: https://github.com/denoland/deno_std/blob/76d8c0159b72f5fa27f605c085dacfe236ffa54c/path/posix.ts#L493
basename: https://github.com/denoland/deno_std/blob/76d8c0159b72f5fa27f605c085dacfe236ffa54c/path/posix.ts#L249