### PR TITLE
fix: inject style in multi formats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ export async function build(_options: Options) {
                 await runEsbuild(options, {
                   pluginContainer,
                   format,
-                  css: index === 0 ? css : undefined,
+                  css: (index === 0 || options.injectStyle) ? css : undefined,
                   logger,
                   buildDependencies,
                 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -692,6 +692,28 @@ test('inject style', async (t) => {
   t.assert(output.includes('.hello{color:red}'))
 })
 
+test('inject style in multi formats', async (t) => {
+  const { outFiles, getFileContent } = await run(
+    t.title,
+    {
+      'input.ts': `export * from './App.svelte'`,
+      'App.svelte': `
+      <span>{msg}</span>
+
+      <style>
+      span {color: red}
+      </style>`,
+    },
+    {
+      flags: ['--inject-style', '--minify', '--format', 'esm,cjs,iife'],
+    }
+  )
+  t.deepEqual(outFiles, ['input.global.js', 'input.js', 'input.mjs'])
+  for (const file of outFiles) {
+    t.assert((await getFileContent(`dist/${file}`)).includes('{color:red}'))
+  }
+})
+
 test('shebang', async (t) => {
   const { outDir } = await run(
     t.title,


### PR DESCRIPTION
style should be bundled into all format files if `option.injectStyle` specified.