### PR TITLE
fix: Pass noExternal to externalPlugin

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -112,6 +112,7 @@ export async function runEsbuild(
     format !== 'iife' &&
       externalPlugin({
         external,
+        noExternal: options.external,
         skipNodeModulesBundle: options.skipNodeModulesBundle,
         tsconfigResolvePaths: options.tsconfigResolvePaths,
       }),

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -112,7 +112,7 @@ export async function runEsbuild(
     format !== 'iife' &&
       externalPlugin({
         external,
-        noExternal: options.external,
+        noExternal: options.noExternal,
         skipNodeModulesBundle: options.skipNodeModulesBundle,
         tsconfigResolvePaths: options.tsconfigResolvePaths,
       }),


### PR DESCRIPTION
Currently, `noExternal` has no effect.