### PR TITLE
Expand define value type to be any json or single type

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -55,7 +55,7 @@ export type Options = {
     [k: string]: string
   }
   define?: {
-    [k: string]: string
+    [k: string]: string | boolean | number | null
   }
   dts?: boolean | string | DtsConfig
   sourcemap?: boolean | 'inline'


### PR DESCRIPTION
The Options['define'] type only allows string values however using any other type like booleans, numbers, etc. are supported by esbuild.