### PR TITLE
fix: buildDependencies lost after build failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,9 @@ export async function build(_options: Options) {
 
           const buildAll = async () => {
             const killPromise = killPreviousProcess()
-            const preBuildDependencies = new Set(buildDependencies)
+            // Store previous build dependencies in case the build failed
+            // So we can restore it
+            const previousBuildDependencies = new Set(buildDependencies)
             buildDependencies.clear()
 
             if (options.clean) {
@@ -219,7 +221,7 @@ export async function build(_options: Options) {
                   logger,
                   buildDependencies,
                 }).catch((error) => {
-                  preBuildDependencies.forEach(buildDependencies.add)
+                  previousBuildDependencies.forEach(v => buildDependencies.add(v))
                   throw error
                 })
               }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ export async function build(_options: Options) {
 
           const buildAll = async () => {
             const killPromise = killPreviousProcess()
+            const preBuildDependencies = new Set(buildDependencies)
             buildDependencies.clear()
 
             if (options.clean) {
@@ -217,6 +218,9 @@ export async function build(_options: Options) {
                   css: index === 0 || options.injectStyle ? css : undefined,
                   logger,
                   buildDependencies,
+                }).catch((error) => {
+                  preBuildDependencies.forEach(buildDependencies.add)
+                  throw error
                 })
               }),
             ])


### PR DESCRIPTION
After the build fails, buildDependencies has been cleared, so the watch cannot continue. Need to restore the previous buildDependencies after the build fails