### PR TITLE
fix: unlink the outDir twice will report an error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,7 @@ export async function removeFiles(patterns: string[], dir: string) {
     cwd: dir,
     absolute: true,
   })
-  await Promise.all(files.map((file) => fs.promises.unlink(file)))
+  files.forEach((file) => fs.existsSync(file) && fs.unlinkSync(file))
 }
 
 export function debouncePromise<T extends unknown[]>(


### PR DESCRIPTION
 no such file or directory, unlink '...\dist\A.mjs'

```ts
import { defineConfig } from "tsup";
import type { Options } from "tsup";
export default defineConfig((options) => {
  const common: Options = {
    clean: true,
  };

  return [
    { ...common, entry: ["./src/A.ts"], outDir: "./dist" },
    { ...common, entry: ["./src/B.ts"], outDir: "./dist" },
  ];
});
```