### PR TITLE
fix: ignore esbuild warning if silent is true

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -8,7 +8,7 @@ import {
 } from 'esbuild'
 import { NormalizedOptions, Format } from '..'
 import { getDeps, loadPkg } from '../load'
-import { Logger } from '../log'
+import { Logger, getSilent } from '../log'
 import { nodeProtocolPlugin } from './node-protocol'
 import { externalPlugin } from './external'
 import { postcssPlugin } from './postcss'
@@ -103,8 +103,8 @@ export async function runEsbuild(
     format === 'iife'
       ? false
       : typeof options.splitting === 'boolean'
-      ? options.splitting
-      : format === 'esm'
+        ? options.splitting
+        : format === 'esm'
 
   const platform = options.platform || 'node'
   const loader = options.loader || {}
@@ -131,12 +131,12 @@ export async function runEsbuild(
     // esbuild's `external` option doesn't support RegExp
     // So here we use a custom plugin to implement it
     format !== 'iife' &&
-      externalPlugin({
-        external,
-        noExternal: options.noExternal,
-        skipNodeModulesBundle: options.skipNodeModulesBundle,
-        tsconfigResolvePaths: options.tsconfigResolvePaths,
-      }),
+    externalPlugin({
+      external,
+      noExternal: options.noExternal,
+      skipNodeModulesBundle: options.skipNodeModulesBundle,
+      tsconfigResolvePaths: options.tsconfigResolvePaths,
+    }),
     options.tsconfigDecoratorMetadata && swcPlugin({ logger }),
     nativeNodeModulesPlugin(),
     postcssPlugin({ css, inject: options.injectStyle }),
@@ -198,8 +198,8 @@ export async function runEsbuild(
         TSUP_FORMAT: JSON.stringify(format),
         ...(format === 'cjs' && injectShims
           ? {
-              'import.meta.url': 'importMetaUrl',
-            }
+            'import.meta.url': 'importMetaUrl',
+          }
           : {}),
         ...options.define,
         ...Object.keys(env).reduce((res, key) => {
@@ -242,7 +242,7 @@ export async function runEsbuild(
     throw error
   }
 
-  if (result && result.warnings) {
+  if (result && result.warnings && !getSilent()) {
     const messages = result.warnings.filter((warning) => {
       if (
         warning.text.includes(

--- a/src/log.ts
+++ b/src/log.ts
@@ -9,10 +9,10 @@ export const colorize = (type: LOG_TYPE, data: any, onlyImportant = false) => {
     type === 'info'
       ? 'blue'
       : type === 'error'
-      ? 'red'
-      : type === 'warn'
-      ? 'yellow'
-      : 'green'
+        ? 'red'
+        : type === 'warn'
+          ? 'yellow'
+          : 'green'
   return colors[color](data)
 }
 
@@ -33,6 +33,10 @@ let silent = false
 
 export function setSilent(isSilent?: boolean) {
   silent = !!isSilent
+}
+
+export function getSilent() {
+  return silent
 }
 
 export type Logger = ReturnType<typeof createLogger>


### PR DESCRIPTION
I don't know if you did it here on purpose or forgot to modify it. When I set `silent: true`, some esbuild warning messages are still printed. I felt it was a bug and therefore fixed it.

Also, if we don't pay attention to the format of the print, can we use `Logger` to print esbuild warning messages, which can reduce the dependence of `consola`. 🙂

