### PR TITLE
feat(minor): use shell option for complex commands in onSuccess

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "resolve": "1.20.0",
     "rollup-plugin-dts": "4.2.1",
     "rollup-plugin-hashbang": "2.2.2",
-    "string-argv": "0.3.1",
     "strip-json-comments": "4.0.0",
     "svelte": "3.46.4",
     "ts-essentials": "9.1.2",
@@ -69,9 +68,9 @@
     "wait-for-expect": "3.0.2"
   },
   "peerDependencies": {
-    "typescript": "^4.1.0",
+    "@swc/core": "^1",
     "postcss": "^8.4.12",
-    "@swc/core": "^1"
+    "typescript": "^4.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,6 @@ specifiers:
   rollup-plugin-dts: 4.2.1
   rollup-plugin-hashbang: 2.2.2
   source-map: 0.8.0-beta.0
-  string-argv: 0.3.1
   strip-json-comments: 4.0.0
   sucrase: ^3.20.3
   svelte: 3.46.4
@@ -76,7 +75,6 @@ devDependencies:
   resolve: 1.20.0
   rollup-plugin-dts: 4.2.1_rymbksdyfyl5jij5b5y6cpv63i
   rollup-plugin-hashbang: 2.2.2
-  string-argv: 0.3.1
   strip-json-comments: 4.0.0
   svelte: 3.46.4
   ts-essentials: 9.1.2_typescript@4.6.3
@@ -1429,11 +1427,6 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    dev: true
-
-  /string-argv/0.3.1:
-    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
-    engines: {node: '>=0.6.19'}
     dev: true
 
   /strip-bom/3.0.0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { loadTsupConfig } from './load'
 import glob from 'globby'
 import { loadTsConfig } from 'bundle-require'
 import { handleError, PrettyError } from './errors'
-import { parseArgsStringToArgv } from 'string-argv'
 import type { ChildProcess } from 'child_process'
 import execa from 'execa'
 import kill from 'tree-kill'
@@ -29,9 +28,9 @@ export const defineConfig = (
     | Options
     | Options[]
     | ((
-        /** The options derived from CLI flags */
-        overrideOptions: Options
-      ) => MaybePromise<Options | Options[]>)
+      /** The options derived from CLI flags */
+      overrideOptions: Options
+    ) => MaybePromise<Options | Options[]>)
 ) => options
 
 const killProcess = ({
@@ -68,8 +67,8 @@ const normalizeOptions = async (
           ? {}
           : undefined
         : typeof _options.dts === 'string'
-        ? { entry: _options.dts }
-        : _options.dts,
+          ? { entry: _options.dts }
+          : _options.dts,
   }
 
   setSilent(options.silent)
@@ -121,9 +120,9 @@ export async function build(_options: Options) {
     _options.config === false
       ? {}
       : await loadTsupConfig(
-          process.cwd(),
-          _options.config === true ? undefined : _options.config
-        )
+        process.cwd(),
+        _options.config === true ? undefined : _options.config
+      )
 
   const configData =
     typeof config.data === 'function'
@@ -244,10 +243,8 @@ export async function build(_options: Options) {
               ])
               await killPromise
               if (options.onSuccess) {
-                const parts = parseArgsStringToArgv(options.onSuccess)
-                const exec = parts[0]
-                const args = parts.splice(1)
-                existingOnSuccess = execa(exec, args, {
+                existingOnSuccess = execa(options.onSuccess, {
+                  shell: true,
                   stdio: 'inherit',
                 })
               }
@@ -274,17 +271,16 @@ export async function build(_options: Options) {
                 typeof options.watch === 'boolean'
                   ? '.'
                   : Array.isArray(options.watch)
-                  ? options.watch.filter(
+                    ? options.watch.filter(
                       (path): path is string => typeof path === 'string'
                     )
-                  : options.watch
+                    : options.watch
 
               logger.info(
                 'CLI',
-                `Watching for changes in ${
-                  Array.isArray(watchPaths)
-                    ? watchPaths.map((v) => '"' + v + '"').join(' | ')
-                    : '"' + watchPaths + '"'
+                `Watching for changes in ${Array.isArray(watchPaths)
+                  ? watchPaths.map((v) => '"' + v + '"').join(' | ')
+                  : '"' + watchPaths + '"'
                 }`
               )
               logger.info(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -279,7 +279,7 @@ test('import css', async () => {
     `,
     'foo.css': `
   $color: blue;
-  
+
   .foo {
     color: $color;
   }
@@ -297,7 +297,7 @@ test('import css in --dts', async () => {
       'input.ts': `
     import './foo.css'
     `,
-      'foo.css': `  
+      'foo.css': `
   .foo {
     color: blue
   }
@@ -425,18 +425,18 @@ test('svelte: typescript support', async () => {
 })
 
 test('onSuccess', async () => {
-  const randomNumber = Math.random() + ''
   const { logs } = await run(
     getTestName(),
     {
       'input.ts': "console.log('test');",
     },
     {
-      flags: ['--onSuccess', 'echo ' + randomNumber],
+      flags: ['--onSuccess', 'echo hello && echo world'],
     }
   )
 
-  expect(logs.includes(randomNumber)).toEqual(true)
+  expect(logs.includes("hello")).toEqual(true)
+  expect(logs.includes("world")).toEqual(true)
 })
 
 test('support baseUrl and paths in tsconfig.json', async () => {
@@ -751,7 +751,7 @@ test('es5 target', async () => {
     export class Foo {
       hi (): void {
         let a = () => 'foo'
-  
+
         console.log(a())
       }
     }
@@ -848,7 +848,7 @@ test('use rollup for treeshaking', async () => {
     getTestName(),
     {
       'input.ts': `
-      export { useRoute } from 'vue-router' 
+      export { useRoute } from 'vue-router'
       `,
     },
     {


### PR DESCRIPTION
Hello,

I activated the `shell` option for executing commands passed to `onSuccess`. It allows for more complicated commands and workflows.

A very concrete use-case is to reboot a web server after the build is done:

```json
{
  "scripts": {
    "dev": "tsup src/index.ts --format esm,cjs --clean --watch src --onSuccess 'pnpm build:types && kill-port 4000 && pnpm start'",
    "build": "tsup src/index.ts --format esm,cjs --clean --onSuccess 'pnpm build:types'",
    "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap",
    "start": "node ./dist/index.js",
  }
}
```

Sorry for the code format changes but it seems like prettier wasn't run on dev?