### PR TITLE
feat: allow onSuccess callback in tsup config file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -331,6 +331,16 @@ tsup src/index.ts --watch --onSuccess "node dist/index.js"
 
 > Warning: You should not use shell scripts, if you need to specify shell scripts you can add it in your "scripts" field and set for example `tsup src/index.ts --watch --onSuccess \"npm run dev\"`
 
+`onSuccess` can also be a `function` that returns `Promise`. For this to work, you need to use `tsup.config.ts` instead of the cli flag: 
+
+```ts
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  onSuccess: async () => { ... }
+})
+```
+
 ### Minify output
 
 You can also minify the output, resulting into lower bundle sizes by using the `--minify` flag.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,9 @@ export const defineConfig = (
     | Options
     | Options[]
     | ((
-      /** The options derived from CLI flags */
-      overrideOptions: Options
-    ) => MaybePromise<Options | Options[]>)
+        /** The options derived from CLI flags */
+        overrideOptions: Options
+      ) => MaybePromise<Options | Options[]>)
 ) => options
 
 const killProcess = ({
@@ -67,8 +67,8 @@ const normalizeOptions = async (
           ? {}
           : undefined
         : typeof _options.dts === 'string'
-          ? { entry: _options.dts }
-          : _options.dts,
+        ? { entry: _options.dts }
+        : _options.dts,
   }
 
   setSilent(options.silent)
@@ -120,9 +120,9 @@ export async function build(_options: Options) {
     _options.config === false
       ? {}
       : await loadTsupConfig(
-        process.cwd(),
-        _options.config === true ? undefined : _options.config
-      )
+          process.cwd(),
+          _options.config === true ? undefined : _options.config
+        )
 
   const configData =
     typeof config.data === 'function'
@@ -159,6 +159,7 @@ export async function build(_options: Options) {
                   esbuildOptions: undefined,
                   plugins: undefined,
                   treeshake: undefined,
+                  onSuccess: undefined,
                 },
               })
               worker.on('message', (data) => {
@@ -186,10 +187,10 @@ export async function build(_options: Options) {
                 })
               } else if (existingOnSuccessFnPromise) {
                 await Promise.race([
-                  existingOnSuccessFnPromise, 
+                  existingOnSuccessFnPromise,
                   // cancel existingOnSuccessFnPromise if it is still running,
                   // using a promise that's been already resolved
-                  Promise.resolve()
+                  Promise.resolve(),
                 ])
               }
               // reset them in all occassions anyway
@@ -285,16 +286,17 @@ export async function build(_options: Options) {
                 typeof options.watch === 'boolean'
                   ? '.'
                   : Array.isArray(options.watch)
-                    ? options.watch.filter(
+                  ? options.watch.filter(
                       (path): path is string => typeof path === 'string'
                     )
-                    : options.watch
+                  : options.watch
 
               logger.info(
                 'CLI',
-                `Watching for changes in ${Array.isArray(watchPaths)
-                  ? watchPaths.map((v) => '"' + v + '"').join(' | ')
-                  : '"' + watchPaths + '"'
+                `Watching for changes in ${
+                  Array.isArray(watchPaths)
+                    ? watchPaths.map((v) => '"' + v + '"').join(' | ')
+                    : '"' + watchPaths + '"'
                 }`
               )
               logger.info(

--- a/src/options.ts
+++ b/src/options.ts
@@ -67,7 +67,7 @@ export type Options = {
   keepNames?: boolean
   watch?: boolean | string | (string | boolean)[]
   ignoreWatch?: string[] | string
-  onSuccess?: string
+  onSuccess?: string | ((...params: any[]) => Promise<any>),
   jsxFactory?: string
   jsxFragment?: string
   outDir?: string

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -443,6 +443,7 @@ test('svelte: typescript support', async () => {
   expect(output).toContain('// Component.svelte')
 })
 
+
 test('onSuccess', async () => {
   const { logs } = await run(
     getTestName(),
@@ -452,6 +453,30 @@ test('onSuccess', async () => {
     {
       flags: ['--onSuccess', 'echo hello && echo world'],
     }
+  )
+
+  expect(logs.includes('hello')).toEqual(true)
+  expect(logs.includes('world')).toEqual(true)
+})
+
+test('onSuccess: use a function from config file', async () => {
+  const { logs } = await run(
+    getTestName(),
+    {
+      'input.ts': "console.log('test');",
+      'tsup.config.ts': `
+        export default {
+          onSuccess: async () => {
+            console.log('hello')
+            await new Promise((resolve) => {
+              setTimeout(() => {
+                console.log('world')
+                resolve('')  
+              }, 1_000)
+            })
+          }
+        }`
+    },
   )
 
   expect(logs.includes('hello')).toEqual(true)


### PR DESCRIPTION
Resolves #637

Allows onSuccess to be a `function` as well as `string`. This option is only available from tsup config file (`tsup.config.ts`) for an obvious reason.

Had to do some little extra work to cancel the promise from `onSuccess` function because `otherTasks()` is used in watch mode which needs to cancel the previous process (= promise) when there's a fresh run caused by a file change. The majority of changes to `src/index.ts` attributes to that.

