### PR TITLE
feat: add option to override tsconfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs'
 import { Worker } from 'worker_threads'
-import type { Buildable, MarkRequired } from 'ts-essentials'
 import { removeFiles, debouncePromise, slash, MaybePromise } from './utils'
 import { loadTsupConfig } from './load'
 import glob from 'globby'
@@ -12,7 +11,7 @@ import execa from 'execa'
 import kill from 'tree-kill'
 import { version } from '../package.json'
 import { createLogger, setSilent } from './log'
-import { NormalizedOptions, Format, Options } from './options'
+import { NormalizedOptions, Format, Options, DtsConfig } from './options'
 import { runEsbuild } from './esbuild'
 import { shebang } from './plugins/shebang'
 import { cjsSplitting } from './plugins/cjs-splitting'
@@ -53,7 +52,7 @@ const normalizeOptions = async (
     ...optionsFromConfigFile,
     ...optionsOverride,
   }
-  const options: Buildable<NormalizedOptions> = {
+  const options: Partial<NormalizedOptions> = {
     target: 'node14',
     outDir: 'dist',
     ..._options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import execa from 'execa'
 import kill from 'tree-kill'
 import { version } from '../package.json'
 import { createLogger, setSilent } from './log'
-import { NormalizedOptions, Format, Options, DtsConfig } from './options'
+import { NormalizedOptions, Format, Options } from './options'
 import { runEsbuild } from './esbuild'
 import { shebang } from './plugins/shebang'
 import { cjsSplitting } from './plugins/cjs-splitting'
@@ -27,9 +27,9 @@ export const defineConfig = (
     | Options
     | Options[]
     | ((
-      /** The options derived from CLI flags */
-      overrideOptions: Options
-    ) => MaybePromise<Options | Options[]>)
+        /** The options derived from CLI flags */
+        overrideOptions: Options
+      ) => MaybePromise<Options | Options[]>)
 ) => options
 
 const killProcess = ({
@@ -66,8 +66,8 @@ const normalizeOptions = async (
           ? {}
           : undefined
         : typeof _options.dts === 'string'
-          ? { entry: _options.dts }
-          : _options.dts,
+        ? { entry: _options.dts }
+        : _options.dts,
   }
 
   setSilent(options.silent)
@@ -107,6 +107,12 @@ const normalizeOptions = async (
     options.tsconfigResolvePaths = tsconfig.data?.compilerOptions?.paths || {}
     options.tsconfigDecoratorMetadata =
       tsconfig.data?.compilerOptions?.emitDecoratorMetadata
+    if (options.dts) {
+      options.dts.compilerOptions = {
+        ...(tsconfig.data.compilerOptions || {}),
+        ...(options.dts.compilerOptions || {}),
+      }
+    }
   } else if (options.tsconfig) {
     throw new PrettyError(`Cannot find tsconfig: ${options.tsconfig}`)
   }
@@ -119,9 +125,9 @@ export async function build(_options: Options) {
     _options.config === false
       ? {}
       : await loadTsupConfig(
-        process.cwd(),
-        _options.config === true ? undefined : _options.config
-      )
+          process.cwd(),
+          _options.config === true ? undefined : _options.config
+        )
 
   const configData =
     typeof config.data === 'function'
@@ -270,16 +276,17 @@ export async function build(_options: Options) {
                 typeof options.watch === 'boolean'
                   ? '.'
                   : Array.isArray(options.watch)
-                    ? options.watch.filter(
+                  ? options.watch.filter(
                       (path): path is string => typeof path === 'string'
                     )
-                    : options.watch
+                  : options.watch
 
               logger.info(
                 'CLI',
-                `Watching for changes in ${Array.isArray(watchPaths)
-                  ? watchPaths.map((v) => '"' + v + '"').join(' | ')
-                  : '"' + watchPaths + '"'
+                `Watching for changes in ${
+                  Array.isArray(watchPaths)
+                    ? watchPaths.map((v) => '"' + v + '"').join(' | ')
+                    : '"' + watchPaths + '"'
                 }`
               )
               logger.info(

--- a/src/options.ts
+++ b/src/options.ts
@@ -29,7 +29,10 @@ export type DtsConfig = {
   banner?: string
   /** Insert at the bottom */
   footer?: string
-  /** Overrides `compilerOptions` */
+  /**
+   * Overrides `compilerOptions`
+   * This option takes higher priority than `compilerOptions` in tsconfig.json
+   */
   compilerOptions?: any
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,6 +3,7 @@ import type { InputOption } from 'rollup'
 import { MarkRequired } from 'ts-essentials'
 import type { Plugin } from './plugin'
 import type { TreeshakingStrategy } from './plugins/tree-shaking'
+import type { CompilerOptions } from 'typescript'
 
 export type Format = 'cjs' | 'esm' | 'iife'
 
@@ -29,6 +30,8 @@ export type DtsConfig = {
   banner?: string
   /** Insert at the bottom */
   footer?: string
+  /** Overrides `compilerOptions` */
+  compilerOptions?: CompilerOptions
 }
 
 export type BannerOrFooter =

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,7 +3,6 @@ import type { InputOption } from 'rollup'
 import { MarkRequired } from 'ts-essentials'
 import type { Plugin } from './plugin'
 import type { TreeshakingStrategy } from './plugins/tree-shaking'
-import type { CompilerOptions } from 'typescript'
 
 export type Format = 'cjs' | 'esm' | 'iife'
 
@@ -31,7 +30,7 @@ export type DtsConfig = {
   /** Insert at the bottom */
   footer?: string
   /** Overrides `compilerOptions` */
-  compilerOptions?: CompilerOptions
+  compilerOptions?: any
 }
 
 export type BannerOrFooter =

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -169,6 +169,7 @@ const getRollupConfig = async (
             preserveSymlinks: false,
             // Ensure we can parse the latest code
             target: ts.ScriptTarget.ESNext,
+            ...(options.dts?.compilerOptions || {}),
           },
         }),
       ].filter(Boolean),

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -15,11 +15,10 @@ import resolveFrom from 'resolve-from'
 
 const logger = createLogger()
 
-const loadCompilerOptions = (tsconfig?: string) => {
-  if (!tsconfig) return {}
-  const configFile = ts.readConfigFile(tsconfig, ts.sys.readFile)
+const parseCompilerOptions = (compilerOptions?: any) => {
+  if (!compilerOptions) return {}
   const { options } = ts.parseJsonConfigFileContent(
-    configFile.config,
+    { compilerOptions },
     ts.sys,
     './'
   )
@@ -83,7 +82,7 @@ const getRollupConfig = async (
 ): Promise<RollupConfig> => {
   setSilent(options.silent)
 
-  const compilerOptions = loadCompilerOptions(options.tsconfig)
+  const compilerOptions = parseCompilerOptions(options.dts?.compilerOptions)
 
   const dtsOptions = options.dts || {}
   dtsOptions.entry = dtsOptions.entry || options.entry
@@ -169,7 +168,6 @@ const getRollupConfig = async (
             preserveSymlinks: false,
             // Ensure we can parse the latest code
             target: ts.ScriptTarget.ESNext,
-            ...(options.dts?.compilerOptions || {}),
           },
         }),
       ].filter(Boolean),


### PR DESCRIPTION
I'm a little confused. Since we have `loadTsConfig`, why we still load the config from `loadCompilerOptions`? I think we can parse it directly.