### PR TITLE
fix: fix `DataCloneError` when DTS is on

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ export async function build(_options: Options) {
                   esbuildOptions: undefined,
                   plugins: undefined,
                   treeshake: undefined,
+                  outExtension: undefined,
                 },
               })
               worker.on('message', (data) => {


### PR DESCRIPTION
As described in #667, `outExtension` and `dts` do not work well together. This PR seems to fix that.