### PR TITLE
Log rollup errors

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -209,8 +209,8 @@ async function runRollup(options: RollupConfig) {
       }, {})
     )
   } catch (error) {
-    logger.error('dts', 'Build error')
     handleError(error)
+    logger.error('dts', 'Build error')
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/egoist/tsup/issues/680

By moving the `handleError` to occur before `logger.error`, the underlying error can be logged to the console, instead of being swallowed.