### PR TITLE
fix: ignore rollup warning if silent is true

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ export async function build(_options: Options) {
                     treeShakingPlugin({
                       treeshake: options.treeshake,
                       name: options.globalName,
+                      silent: options.silent,
                     }),
                     cjsSplitting(),
                     es5(),

--- a/src/plugins/tree-shaking.ts
+++ b/src/plugins/tree-shaking.ts
@@ -9,10 +9,12 @@ export type TreeshakingStrategy =
 
 export const treeShakingPlugin = ({
   treeshake,
-  name
+  name,
+  silent,
 }: {
   treeshake?: TreeshakingStrategy,
   name?: string
+  silent?: boolean
 }): Plugin => {
   return {
     name: 'tree-shaking',
@@ -38,6 +40,7 @@ export const treeShakingPlugin = ({
         treeshake: treeshake,
         makeAbsoluteExternalsRelative: false,
         preserveEntrySignatures: 'exports-only',
+        onwarn: silent ? () => {} : undefined,
       })
 
       const result = await bundle.generate({


### PR DESCRIPTION
Supplement to the #643.
When I set `silent: true` and `treeshake: true`, some rollup messages are still printed.