### PR TITLE
feat: add tsup.confg.* file support in watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,20 @@ export async function build(_options: Options) {
                 let shouldSkipChange = false
 
                 if (options.watch === true) {
+                  // If tsup.config changes, close current watcher and rerun build
+                  if (
+                    [
+                      'tsup.config.ts',
+                      'tsup.config.js',
+                      'tsup.config.cjs',
+                      'tsup.config.mjs',
+                      'tsup.config.json'
+                    ].includes(file)
+                  ) {
+                    await watcher.close();
+                    await build(_options)
+                    return;
+                  }
                   if (file === 'package.json' && !buildDependencies.has(file)) {
                     const currentHash = await getAllDepsHash(process.cwd())
                     shouldSkipChange = currentHash === depsHash


### PR DESCRIPTION
Since watch mode doesn't watch the `tsup.config.*` file, so every time I change the config I need to kill the watch process and restart.