### PR TITLE
feat: allow to exclude dependencies from specific package.json

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ This will output `dist/index.js` and `dist/cli.js`.
 
 ### Excluding packages
 
-By default tsup bundles all `import`-ed modules but `dependencies` and `peerDependencies` in your `packages.json` are always excluded, you can also use `--external <module>` flag to mark other packages as external.
+By default tsup bundles all `import`-ed modules but `dependencies` and `peerDependencies` in your `packages.json` are always excluded, you can also use `--external <module|pkgJson>` flag to mark other packages or other special `package.json`'s `dependencies` and `peerDependencies` as external.
 
 ### Excluding all packages
 

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -58,7 +58,7 @@ export async function main(options: Options = {}) {
       'Replace a global variable with an import from another file'
     )
     .option('--define.* <value>', 'Define compile-time constants')
-    .option('--external <name>', 'Mark specific packages as external')
+    .option('--external <name>', 'Mark specific packages / package.json (dependencies and peerDependencies) as external')
     .option('--global-name <name>', 'Global variable name for iife format')
     .option('--jsxFactory <jsxFactory>', 'Name of JSX factory function', {
       default: 'React.createElement',

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -74,7 +74,8 @@ var input_exports = {};
 __export(input_exports, {
   bar: () => import_bar.bar,
   baz: () => baz,
-  foo: () => import_foo.foo
+  foo: () => import_foo.foo,
+  qux: () => import_qux.qux
 });
 module.exports = __toCommonJS(input_exports);
 var import_foo = require(\\"foo\\");
@@ -82,11 +83,15 @@ var import_bar = require(\\"bar\\");
 
 // node_modules/baz/index.ts
 var baz = \\"baz\\";
+
+// input.ts
+var import_qux = require(\\"qux\\");
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   bar,
   baz,
-  foo
+  foo,
+  qux
 });
 "
 `;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -344,6 +344,7 @@ test('external', async () => {
     'input.ts': `export {foo} from 'foo'
     export {bar} from 'bar'
     export {baz} from 'baz'
+    export {qux} from 'qux'
     `,
     'node_modules/foo/index.ts': `export const foo = 'foo'`,
     'node_modules/foo/package.json': `{"name":"foo","version":"0.0.0"}`,
@@ -351,9 +352,12 @@ test('external', async () => {
     'node_modules/bar/package.json': `{"name":"bar","version":"0.0.0"}`,
     'node_modules/baz/index.ts': `export const baz = 'baz'`,
     'node_modules/baz/package.json': `{"name":"baz","version":"0.0.0"}`,
+    'node_modules/qux/index.ts': `export const qux = 'qux'`,
+    'node_modules/qux/package.json': `{"name":"qux","version":"0.0.0"}`,
+    'another/package.json': `{"name":"another-pkg","dependencies":{"qux":"0.0.0"}}`,
     'tsup.config.ts': `
     export default {
-      external: [/f/, 'bar']
+      external: [/f/, 'bar', 'another/package.json']
     }
     `,
   })


### PR DESCRIPTION
`external` now support to exclude special `package.json`'s `dependencies` and `peerDependencies`.

motivation: In monorepo, some `dependencies` are written as public in `package.json` under the workspace, and now users can specify special `package.json` to exclude them.