### PR TITLE
fix: respect noExternal option with Tsup node

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,8 @@ tsup automatically excludes packages specified in the `dependencies` and `peerDe
 tsup-node src/index.ts
 ```
 
-All other CLI flags still apply to this command.
+All other CLI flags still apply to this command. You can still use the `noExternal` option to reinclude packages in the bundle,
+for example packages that belong to a local monorepository.
 
 **If the regular `tsup` command doesn't work for you, please submit an issue with a link to your repo so we can make the default command better.**
 

--- a/src/esbuild/external.ts
+++ b/src/esbuild/external.ts
@@ -28,9 +28,14 @@ export const externalPlugin = ({
           if (match(args.path, resolvePatterns)) {
             return
           }
+          // Respect explicit external/noExternal conditions
           if (match(args.path, noExternal)) {
             return
           }
+          if (match(args.path, external)) {
+            return { external: true }
+          }
+          // Exclude any other import that looks like a Node module
           if (NON_NODE_MODULE_RE.test(args.path)) {
             return {
               path: args.path,
@@ -38,16 +43,17 @@ export const externalPlugin = ({
             }
           }
         })
+      } else {
+        build.onResolve({ filter: /.*/ }, (args) => {
+          // Respect explicit external/noExternal conditions
+          if (match(args.path, noExternal)) {
+            return
+          }
+          if (match(args.path, external)) {
+            return { external: true }
+          }
+        })
       }
-
-      build.onResolve({ filter: /.*/ }, (args) => {
-        if (match(args.path, noExternal)) {
-          return
-        }
-        if (match(args.path, external)) {
-          return { external: true }
-        }
-      })
     },
   }
 }

--- a/src/esbuild/external.ts
+++ b/src/esbuild/external.ts
@@ -28,6 +28,9 @@ export const externalPlugin = ({
           if (match(args.path, resolvePatterns)) {
             return
           }
+          if (match(args.path, noExternal)) {
+            return
+          }
           if (NON_NODE_MODULE_RE.test(args.path)) {
             return {
               path: args.path,

--- a/src/options.ts
+++ b/src/options.ts
@@ -116,6 +116,7 @@ export type Options = {
   silent?: boolean
   /**
    * Skip node_modules bundling
+   * Will still bundle modules matching the `noExternal` option
    */
   skipNodeModulesBundle?: boolean
   /**

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -135,50 +135,6 @@ var answer = 42;
 "
 `;
 
-exports[`noExternal are respected when skipNodeModulesBundle is true 1`] = `
-"\\"use strict\\";
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __export = (target, all) => {
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
-var __copyProps = (to, from, except, desc) => {
-  if (from && typeof from === \\"object\\" || typeof from === \\"function\\") {
-    for (let key of __getOwnPropNames(from))
-      if (!__hasOwnProp.call(to, key) && key !== except)
-        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
-  }
-  return to;
-};
-var __toCommonJS = (mod) => __copyProps(__defProp({}, \\"__esModule\\", { value: true }), mod);
-
-// input.ts
-var input_exports = {};
-__export(input_exports, {
-  bar: () => import_bar.bar,
-  baz: () => import_baz.baz,
-  foo: () => foo
-});
-module.exports = __toCommonJS(input_exports);
-
-// node_modules/foo/index.ts
-var foo = \\"foo\\";
-
-// input.ts
-var import_bar = require(\\"bar\\");
-var import_baz = require(\\"baz\\");
-// Annotate the CommonJS export names for ESM import in node:
-0 && (module.exports = {
-  bar,
-  baz,
-  foo
-});
-"
-`;
-
 exports[`node protocol 1`] = `
 "\\"use strict\\";
 var __create = Object.create;

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -135,6 +135,50 @@ var answer = 42;
 "
 `;
 
+exports[`noExternal are respected when skipNodeModulesBundle is true 1`] = `
+"\\"use strict\\";
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === \\"object\\" || typeof from === \\"function\\") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, \\"__esModule\\", { value: true }), mod);
+
+// input.ts
+var input_exports = {};
+__export(input_exports, {
+  bar: () => import_bar.bar,
+  baz: () => import_baz.baz,
+  foo: () => foo
+});
+module.exports = __toCommonJS(input_exports);
+
+// node_modules/foo/index.ts
+var foo = \\"foo\\";
+
+// input.ts
+var import_bar = require(\\"bar\\");
+var import_baz = require(\\"baz\\");
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  bar,
+  baz,
+  foo
+});
+"
+`;
+
 exports[`node protocol 1`] = `
 "\\"use strict\\";
 var __create = Object.create;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -379,7 +379,9 @@ test('noExternal are respected when skipNodeModulesBundle is true', async () => 
     }
     `,
   })
-  expect(output).toMatchSnapshot()
+  expect(output).toContain(`var foo = "foo"`)
+  expect(output).not.toContain(`var bar = "bar"`)
+  expect(output).not.toContain(`var baz = "baz"`)
 })
 
 test('disable code splitting to get proper module.exports =', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -360,6 +360,28 @@ test('external', async () => {
   expect(output).toMatchSnapshot()
 })
 
+test('noExternal are respected when skipNodeModulesBundle is true', async () => {
+  const { output } = await run(getTestName(), {
+    'input.ts': `export {foo} from 'foo'
+    export {bar} from 'bar'
+    export {baz} from 'baz'
+    `,
+    'node_modules/foo/index.ts': `export const foo = 'foo'`,
+    'node_modules/foo/package.json': `{"name":"foo","version":"0.0.0"}`,
+    'node_modules/bar/index.ts': `export const bar = 'bar'`,
+    'node_modules/bar/package.json': `{"name":"bar","version":"0.0.0"}`,
+    'node_modules/baz/index.ts': `export const baz = 'baz'`,
+    'node_modules/baz/package.json': `{"name":"baz","version":"0.0.0"}`,
+    'tsup.config.ts': `
+    export default {
+      skipNodeModulesBundle: true,
+      noExternal: [/foo/]
+    }
+    `,
+  })
+  expect(output).toMatchSnapshot()
+})
+
 test('disable code splitting to get proper module.exports =', async () => {
   const { output } = await run(
     getTestName(),


### PR DESCRIPTION
Fixes #718 

/!\ I haven't tested if it still builds (but I only touched 2 lines of code) + this might be a slight breaking change if some people use `tsup-node` and accidentally had a  "noExternal" option set (before this PR, the noExternal would be ignored, after this PR, it is correctly considered thus bundling more packages).
