### PR TITLE
fix: Configure Rollup's external to support subpaths too

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -171,7 +171,11 @@ const getRollupConfig = async (
           },
         }),
       ].filter(Boolean),
-      external: [...deps, ...(options.external || [])],
+      external: [
+        // Exclude dependencies, e.g. `lodash`, `lodash/get`
+        ...deps.map((dep) => new RegExp(`^${dep}($|\\/|\\\\)`)),
+        ...(options.external || [])
+      ],
     },
     outputConfig: {
       dir: options.outDir || 'dist',

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -199,6 +199,15 @@ var input_default = foo_default;
 "
 `;
 
+exports[`not bundle \`package/subpath\` in dts (resolve) 1`] = `
+"import * as foo_bar from 'foo/bar';
+
+declare const stuff: foo_bar.Foobar;
+
+export { stuff };
+"
+`;
+
 exports[`support baseUrl and paths in tsconfig.json 1`] = `
 "var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -136,7 +136,7 @@ test('bundle vue and ts-essentials with --dts --dts-resolve flag', async () => {
 })
 
 test('bundle @egoist/path-parser with --dts --dts-resolve flag', async () => {
-  const { getFileContent } = await run(
+  await run(
     getTestName(),
     {
       'input.ts': `import { PathParser } from '@egoist/path-parser'
@@ -150,6 +150,23 @@ test('bundle @egoist/path-parser with --dts --dts-resolve flag', async () => {
       flags: ['--dts', '--dts-resolve'],
     }
   )
+})
+
+test('not bundle `package/subpath` in dts (resolve)', async () => {
+  const { getFileContent } = await run(
+    getTestName(),
+    {
+      'package.json': `{ "dependencies": { "foo": "*" } }`,
+      'input.ts': `export const stuff: import('foo/bar').Foobar = { foo: 'foo', bar: 'bar' };`,
+      'node_modules/foo/bar.d.ts': `export type Foobar = { foo: 'foo', bar: 'bar' }`,
+      'node_modules/foo/package.json': `{ "name": "foo", "version": "0.0.0" }`,
+    },
+    { 
+      flags: ['--dts', '--dts-resolve'],
+    }
+  )
+  const content = await getFileContent('dist/input.d.ts')
+  expect(content).toMatchSnapshot()
 })
 
 test('enable --dts-resolve for specific module', async () => {


### PR DESCRIPTION
# Summary

This PR fixes an issue with `--dts-resolve`.

When relying on types coming `from 'some-package/some-subpath'`, anything that is not imported `from 'some-package'` would end up getting unnecessarily bundled into the emitted `.d.ts` bundle.

It seems we were configuring Rollup's `external` with exact package names.

Here we're adjusting to use the same regex approach taken with esbuild:
https://github.com/egoist/tsup/blob/d074dd9c33adf85bcd149e79c9d141517a956ce0/src/esbuild/index.ts#L80-L81