### PR TITLE
clarify documentation regarding `clean` option

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -105,7 +105,7 @@ export type Options = {
    */
   splitting?: boolean
   /**
-   * Clean output directory before each build
+   * Clean output directory before each build. Does not remove `*.d.ts` files by default.
    */
   clean?: boolean | string[]
   esbuildPlugins?: EsbuildPlugin[]


### PR DESCRIPTION
I noticed [via code inspection](https://github.com/egoist/tsup/blob/48b3381b15562490870b0cf32f15252038958384/src/index.ts#L217-L222) that specifying `clean: true` does not remove `*.d.ts` files by default, which was unexpected to me. This updates the documentation for this option to clarify that.