### PR TITLE
fix: clean d.ts files if "dts" option is false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,13 @@ export async function build(_options: Options) {
                 const extraPatterns = Array.isArray(options.clean)
                   ? options.clean
                   : []
+                // Don't clear d.ts files here if we are generating them
+                // They will be handled by the tsup:clean rollup plugin
+                if (options.dts) {
+                  extraPatterns.push('!**/*.d.ts');
+                }
                 await removeFiles(
-                  ['**/*', '!**/*.d.ts', ...extraPatterns],
+                  ['**/*', ...extraPatterns],
                   options.outDir
                 )
                 logger.info('CLI', 'Cleaning output folder')

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,8 @@ export async function build(_options: Options) {
                 const extraPatterns = Array.isArray(options.clean)
                   ? options.clean
                   : []
-                // Don't clear d.ts files here if we are generating them
-                // They will be handled by the tsup:clean rollup plugin
+                // .d.ts files are removed in the `dtsTask` instead
+                // `dtsTask` is a separate process, which might start before `mainTasks`
                 if (options.dts) {
                   extraPatterns.unshift('!**/*.d.ts');
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ export async function build(_options: Options) {
                 // Don't clear d.ts files here if we are generating them
                 // They will be handled by the tsup:clean rollup plugin
                 if (options.dts) {
-                  extraPatterns.push('!**/*.d.ts');
+                  extraPatterns.unshift('!**/*.d.ts');
                 }
                 await removeFiles(
                   ['**/*', ...extraPatterns],


### PR DESCRIPTION
See https://github.com/egoist/tsup/pull/746 for my initial confusion. I generate my types through a separate process (manual `tsc` invocation), and was confused when `clean: true` was not removing them when running tsup.