### PR TITLE
Provide JSON Schema Store 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,20 +134,26 @@ The `options` here is derived from CLI flags.
 }
 ```
 
-Developers who are using [vscode](https://code.visualstudio.com/) can associate the JSON Schema Store in their workspace  settings to provide intellisense capabilities on the `tsup` option via CDN. Provide the following configuration in your `.vscode/settings.json` file:
+#### JSON Schema Stores
+
+Developers who are using [vscode](https://code.visualstudio.com/) or text editor which supports the JSON Language Server can leverage the [tsup schema store](https://unpkg.com/tsup/schema.json) via CDN. This schema store will provide intellisense capabilities such as completions, validations and descriptions within JSON file configurations like the `tsup.config.json` and `package.json` (tsup) property.
+
+Provide the following configuration in your `.vscode/settings.json` (or global) settings file:
 
 ```json
 {
    "json.schemas": [
     {
+      "url": "https://unpkg.com/tsup/schema.json",
       "fileMatch": [
-        "package.json"
-      ],
-      "url": "https://unpkg.com/tsup/schema.json"
+        "package.json",
+        "tsup.config.json"
+      ]
     }
   ],
 }
 ```
+
 
 ### Multiple entrypoints
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,7 +134,7 @@ The `options` here is derived from CLI flags.
 }
 ```
 
-#### JSON Schema Stores
+#### JSON Schema Store
 
 Developers who are using [vscode](https://code.visualstudio.com/) or text editor which supports the JSON Language Server can leverage the [tsup schema store](https://unpkg.com/tsup/schema.json) via CDN. This schema store will provide intellisense capabilities such as completions, validations and descriptions within JSON file configurations like the `tsup.config.json` and `package.json` (tsup) property.
 
@@ -142,7 +142,7 @@ Provide the following configuration in your `.vscode/settings.json` (or global) 
 
 ```json
 {
-   "json.schemas": [
+  "json.schemas": [
     {
       "url": "https://unpkg.com/tsup/schema.json",
       "fileMatch": [
@@ -150,7 +150,7 @@ Provide the following configuration in your `.vscode/settings.json` (or global) 
         "tsup.config.json"
       ]
     }
-  ],
+  ]
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,21 @@ The `options` here is derived from CLI flags.
 }
 ```
 
+Developers who are using [vscode](https://code.visualstudio.com/) can associate the JSON Schema Store in their workspace  settings to provide intellisense capabilities on the `tsup` option via CDN. Provide the following configuration in your `.vscode/settings.json` file:
+
+```json
+{
+   "json.schemas": [
+    {
+      "fileMatch": [
+        "package.json"
+      ],
+      "url": "https://unpkg.com/tsup/schema.json"
+    }
+  ],
+}
+```
+
 ### Multiple entrypoints
 
 Beside using positional arguments `tsup [...files]` to specify multiple entrypoints, you can also use the cli flag `--entry`:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "/dist",
-    "/assets"
+    "/assets",
+    "/schema.json"
   ],
   "author": "EGOIST",
   "license": "MIT",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "tsup",
+  "version": 1.1,
+  "definitions": {
+    "options": {
+      "type": "object",
+      "markdownDescription": "Configuration options for [tsup](https://tsup.egoist.dev)",
+      "additionalProperties": false,
+      "properties": {
+        "entry": {
+          "markdownDescription": "Files that each serve as an input to the bundling algorithm.\n\n---\nReferences:\n- [Entry Points](https://esbuild.github.io/api/#entry-points) - esbuild\n - [Multiple Entrypoints](https://tsup.egoist.sh/#multiple-entrypoints) - tsup",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "treeshake": {
+          "markdownDescription": "By default esbuild already does treeshaking but this option allow you to perform additional treeshaking with Rollup and result in smaller bundle size.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["smallest", "safest", "recommended"]
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional config name to show in CLI output"
+        },
+        "legacyOutput": {
+          "type": "boolean",
+          "description": "Output different formats to different folder instead of using different extension"
+        },
+        "target": {
+          "markdownDescription": "This sets the target environment for the generated code\n\n---\nReferences:\n- [Target](https://esbuild.github.io/api/#target) - esbuild",
+          "default": "node14",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "minify": {
+          "type": "boolean",
+          "description": "When enabled, the generated code will be minified instead of pretty-printed."
+        },
+        "minifyWhitespace": {
+          "type": "boolean"
+        },
+        "minifyIdentifiers": {
+          "type": "boolean"
+        },
+        "minifySyntax": {
+          "type": "boolean"
+        },
+        "keepNames": {
+          "type": "boolean"
+        },
+        "watch": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": ["string", "boolean"]
+              }
+            }
+          ]
+        },
+        "ignoreWatch": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "onSuccess": {
+          "type": "string"
+        },
+        "jsxFactory": {
+          "type": "string"
+        },
+        "jsxFragment": {
+          "type": "string"
+        },
+        "outDir": {
+          "type": "string"
+        },
+        "format": {
+          "oneOf": [
+            {
+              "enum": ["cjs", "iife", "esm"],
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": ["cjs", "iife", "esm"]
+              }
+            }
+          ]
+        },
+        "globalName": {
+          "type": "string"
+        },
+        "env": {
+          "type": "object"
+        },
+        "define": {
+          "type": "object"
+        },
+        "dts": {
+          "markdownDescription": "This will emit `./dist/index.js` and `./dist/index.d.ts`.\n\nIf you have multiple entry files, each entry will get a corresponding `.d.ts` file. So when you only want to generate declaration file for a single entry, use `--dts <entry>` format, e.g. `--dts src/index.ts`.\n\n**Note** that `--dts` does not resolve external (aka in node_modules) types used in the `.d.ts file`, if that's somehow a requirement, try the experimental `--dts-resolve` flag instead.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "entry": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "sourcemap": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "enum": ["inline"]
+            }
+          ]
+        },
+        "noExternal": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Always bundle modules matching given patterns"
+        },
+        "external": {
+          "description": "Don't bundle these modules",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaceNodeEnv": {
+          "type": "boolean",
+          "markdownDescription": "Replace `process.env.NODE_ENV` with `production` or `development` `production` when the bundled is minified, `development` otherwise"
+        },
+        "splitting": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "You may want to disable code splitting sometimes: [`#255`](https://github.com/egoist/tsup/issues/255)"
+        },
+        "clean": {
+          "description": "Clean output directory before each buil",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "silent": {
+          "type": "boolean",
+          "description": "Suppress non-error logs (excluding \"onSuccess\" process output)"
+        },
+        "skipNodeModulesBundle": {
+          "type": "boolean",
+          "description": "Skip node_modules bundling"
+        },
+        "pure": {
+          "markdownDescription": "See:\n- [Pure](https://esbuild.github.io/api/#pure) - esbuild",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "bundle": {
+          "default": true,
+          "type": "boolean",
+          "description": "Disable bundling, default to true"
+        },
+        "inject": {
+          "markdownDescription": "This option allows you to automatically replace a global variable with an import from another file.\n\n---\nSee:\n- [Inject](https://esbuild.github.io/api/#inject) - esbuild",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "metafile": {
+          "type": "boolean",
+          "markdownDescription": "Emit esbuild metafile.\n\n---\nSee:\n- [Metafile](https://esbuild.github.io/api/#metafile) - esbuild"
+        },
+        "footer": {
+          "type": "object",
+          "properties": {
+            "js": {
+              "type": "string"
+            },
+            "css": {
+              "type": "string"
+            }
+          }
+        },
+        "banner": {
+          "type": "object",
+          "properties": {
+            "js": {
+              "type": "string"
+            },
+            "css": {
+              "type": "string"
+            }
+          }
+        },
+        "platform": {
+          "description": "Target platform",
+          "type": "string",
+          "default": "node",
+          "enum": ["node", "browser"]
+        },
+        "config": {
+          "markdownDescription": "Disable config file with `false` or pass a custom config filename",
+          "type": ["boolean", "string"]
+        },
+        "tsconfig": {
+          "type": "string",
+          "description": " Use a custom tsconfig"
+        },
+        "injectStyle": {
+          "type": "boolean",
+          "default": false,
+          "description": "Inject CSS as style tags to document head"
+        },
+        "shims": {
+          "type": "boolean",
+          "default": false,
+          "description": "Inject cjs and esm shims if needed"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "tsup": {
+      "$ref": "#/definitions/options"
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -6,17 +6,20 @@
     {
       "type": "object",
       "required": ["tsup"],
+      "additionalProperties": true,
       "properties": {
         "tsup": {
           "type": ["object", "array"],
           "oneOf": [
             {
               "type": "object",
+              "additionalProperties": false,
               "$ref": "#/definitions/options"
             },
             {
               "type": "array",
               "items": {
+                "additionalProperties": false,
                 "$ref": "#/definitions/options"
               }
             }
@@ -45,7 +48,6 @@
     "options": {
       "type": "object",
       "markdownDescription": "Configuration options for [tsup](https://tsup.egoist.dev)",
-      "additionalProperties": false,
       "properties": {
         "entry": {
           "markdownDescription": "Files that each serve as an input to the bundling algorithm.\n\n---\nReferences:\n- [Entry Points](https://esbuild.github.io/api/#entry-points) - esbuild\n - [Multiple Entrypoints](https://tsup.egoist.sh/#multiple-entrypoints) - tsup",

--- a/schema.json
+++ b/schema.json
@@ -2,6 +2,45 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "tsup",
   "version": 1.1,
+  "anyOf": [
+    {
+      "type": "object",
+      "required": ["tsup"],
+      "properties": {
+        "tsup": {
+          "type": ["object", "array"],
+          "oneOf": [
+            {
+              "type": "object",
+              "$ref": "#/definitions/options"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/options"
+              }
+            }
+          ]
+
+        }
+      }
+    },
+    {
+      "type": ["object", "array"],
+      "oneOf": [
+        {
+          "type": "object",
+          "$ref": "#/definitions/options"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/options"
+          }
+        }
+      ]
+    }
+  ],
   "definitions": {
     "options": {
       "type": "object",
@@ -306,12 +345,6 @@
           "description": "Inject cjs and esm shims if needed"
         }
       }
-    }
-  },
-  "type": "object",
-  "properties": {
-    "tsup": {
-      "$ref": "#/definitions/options"
     }
   }
 }


### PR DESCRIPTION
Touched on this briefly in https://github.com/egoist/tsup/issues/654 

This will allow users to easily extend  intellisense capabilities to the `package.json` file if choosing to pass configurations this way. Users working with vscode or an editor which support the JSON Language Server can optionally choose to implement this.

Consumers will need to point to `https://unpkg.com/tsup/schema.json` if they choose to leverage the feature within their editor.