### PR TITLE
fix typo in postcssPlugin

### DIFF
--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -89,7 +89,7 @@ export const postcssPlugin = ({
         // Load postcss config
         const { plugins, options } = await getPostcssConfig(args.path)
 
-        if (plugins || plugins.length > 0) {
+        if (plugins && plugins.length > 0) {
           // Load postcss
           const postcss = getPostcss()
           if (!postcss) {


### PR DESCRIPTION
When building with tsup I have configured esbuild to use the new [`copy` loader](https://esbuild.github.io/content-types/#copy) for CSS files:
```
const { build } = require('tsup');
build({
  // ...
  loader: {
  	'.css': 'copy'
  },
});
```

Unfortunately this is causing an error when building due to an old version of `postcss` I have in my dependency tree:
```
✘ [ERROR] [plugin postcss] postcss.default is not a function

    ../../utilities/module-scripts/node_modules/tsup/dist/index.js:1348:74:
      1348 │           const result = await (postcss == null ? void 0 : postcss.default(plugins).process(contents, { ...options, from: args.path }));
```

I was trying to figure out why tsup was trying to invoke postcss at all, and discovered what looks like a typo, which causes invocation of postcss even if there is no postcss config present.

One thing I am not sure about: I feel like given my config we should not be including the esbuild `postcssPlugin` at all? So maybe this should also be fixed at a higher level? But this was sufficient to avoid the error.