### PR TITLE
Fix a race between dts clean and generate

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -115,10 +115,13 @@ const getRollupConfig = async (
 
   const tsupCleanPlugin: Plugin = {
     name: 'tsup:clean',
-    async buildStart() {
-      if (options.clean) {
-        await removeFiles(['**/*.d.ts'], options.outDir)
-      }
+    buildStart: {
+      order: 'pre',
+      async handler() {
+        if (options.clean) {
+          await removeFiles(['**/*.d.ts'], options.outDir)
+        }
+      },
     },
   }
 


### PR DESCRIPTION
Rollup's `buildStart` hook runs in parallel - see https://github.com/rollup/rollup/blob/master/docs/05-plugin-development.md#buildstart As described in their "build hooks" section, `parallel` hooks "will be run in the specified plugin order. If a hook is async, subsequent hooks of this kind will be run in parallel and not wait for the current hook."
Since `buildStart` is parallel and we hadn't specified `sequential: true` or `order: xxx`, this plugin's `buildStart` hook could get run at the same time as other `buildStart` hooks. This caused a race condition when generating `.d.ts` files, and caused TSC errors consistently every other run of `tsup`.

This commit ensures that the clean plugin will always run before the `.d.ts` generation step, preventing the race.