### PR TITLE
fix: add "--" to options type

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -181,6 +181,7 @@ export type Options = {
    * This can result in smaller bundle size
    */
   treeshake?: TreeshakingStrategy
+  ['--']: string[]
 }
 
 export type NormalizedOptions = Omit<


### PR DESCRIPTION
This property seems to always be in the options from `cac`, so it would be useful for the typings to reflect that.