### PR TITLE
fix: use postMessage instead of console in worker thread

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,13 @@ export async function build(_options: Options) {
                   reject(new Error('error occured in dts build'))
                 } else if (data === 'success') {
                   resolve()
+                } else {
+                  const { type, text } = data
+                  if (type === 'log') {
+                    console.log(text)
+                  } else if (type === 'error') {
+                    console.error(text)
+                  }
                 }
               })
             })


### PR DESCRIPTION
resolve #776 

use `parentPort.postMessage` as a workaround for `console.log` in worker thread ~