### PR TITLE
feat: update rollup-plugin-dts to support custom tsconfig and preserve export {} for file that have no exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "postcss-simple-vars": "6.0.3",
     "prettier": "2.5.1",
     "resolve": "1.20.0",
-    "rollup-plugin-dts": "5.0.0",
+    "rollup-plugin-dts": "5.1.0",
     "rollup-plugin-hashbang": "2.2.2",
     "strip-json-comments": "4.0.0",
     "svelte": "3.46.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ specifiers:
   resolve: 1.20.0
   resolve-from: ^5.0.0
   rollup: ^3.2.5
-  rollup-plugin-dts: 5.0.0
+  rollup-plugin-dts: 5.1.0
   rollup-plugin-hashbang: 2.2.2
   source-map: 0.8.0-beta.0
   strip-json-comments: 4.0.0
@@ -73,7 +73,7 @@ devDependencies:
   postcss-simple-vars: 6.0.3_postcss@8.4.12
   prettier: 2.5.1
   resolve: 1.20.0
-  rollup-plugin-dts: 5.0.0_mwekjofbfztuuh2kb3ofhfbyx4
+  rollup-plugin-dts: 5.1.0_mwekjofbfztuuh2kb3ofhfbyx4
   rollup-plugin-hashbang: 2.2.2
   strip-json-comments: 4.0.0
   svelte: 3.46.4
@@ -1375,8 +1375,8 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rollup-plugin-dts/5.0.0_mwekjofbfztuuh2kb3ofhfbyx4:
-    resolution: {integrity: sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==}
+  /rollup-plugin-dts/5.1.0_mwekjofbfztuuh2kb3ofhfbyx4:
+    resolution: {integrity: sha512-R+4cVEhu9LfAlR1hqp1D67nO5hsiYFSsbVa2Uj/xchN6WxN4Ct9VjuEP1mw7f4dKJR5rj+OtjUz5cVINX51eFA==}
     engines: {node: '>=v14'}
     peerDependencies:
       rollup: ^3.0.0
@@ -1446,6 +1446,7 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
     dev: true
 
   /strip-bom/3.0.0:

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -151,6 +151,7 @@ const getRollupConfig = async (
         jsonPlugin(),
         ignoreFiles,
         dtsPlugin.default({
+          tsconfig: options.tsconfig,
           compilerOptions: {
             ...compilerOptions,
             baseUrl: compilerOptions.baseUrl || '.',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1143,3 +1143,58 @@ test('override target in tsconfig.json', async () => {
     )
   ).rejects.toThrowError(`Top-level await is not available in the configured target environment ("es2018")`)
 })
+
+test(`custom tsconfig should pass to dts plugin`, async () => {
+  const { outFiles } = await run(
+    getTestName(),
+    {
+      'input.ts': `export const foo = { name: 'foo'}`, 
+      'tsconfig.json': `{
+        "compilerOptions": {
+          "baseUrl":".",
+          "target": "esnext",
+          "incremental": true
+        }
+      }`,
+      'tsconfig.build.json': `{
+        "compilerOptions": {
+          "baseUrl":".",
+          "target": "esnext"
+        }
+      }`,
+      'tsup.config.ts': `
+        export default {
+          entry: ['src/input.ts'],
+          format: 'esm',
+          tsconfig: './tsconfig.build.json',
+          dts: {
+            only: true
+          }
+        }
+      `,
+    })
+    expect(outFiles).toEqual(['input.d.ts'])
+})
+
+test(`should generate export {} when there are no exports in source file`, async () => {
+  const { outFiles, getFileContent } = await run(
+    getTestName(),
+    {
+      'input.ts': `const a = 'a'`, 
+      'tsconfig.json': `{
+        "compilerOptions": {
+          "baseUrl":".",
+          "target": "esnext",
+        }
+      }`,
+      'tsup.config.ts': `
+        export default {
+          entry: ['src/input.ts'],
+          format: 'esm',
+          dts: true
+        }
+      `,
+    })
+    expect(outFiles).toEqual(['input.d.ts', 'input.mjs'])
+    expect(await getFileContent('dist/input.d.ts')).toContain('export { }')
+})


### PR DESCRIPTION
close #762 
close #791 

update `rollup-plugin-dts` to latest version:
* respect custom tsconfig option in `tsup.config.ts` 
* generate `export {}` for input file that have no exports.