### PR TITLE
chore(docs): using jsdelivr insted of unpkg

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ The `options` here is derived from CLI flags.
 
 #### JSON Schema Store
 
-Developers who are using [vscode](https://code.visualstudio.com/) or text editor which supports the JSON Language Server can leverage the [tsup schema store](https://unpkg.com/tsup/schema.json) via CDN. This schema store will provide intellisense capabilities such as completions, validations and descriptions within JSON file configurations like the `tsup.config.json` and `package.json` (tsup) property.
+Developers who are using [vscode](https://code.visualstudio.com/) or text editor which supports the JSON Language Server can leverage the [tsup schema store](https://cdn.jsdelivr.net/npm/tsup/schema.json) via CDN. This schema store will provide intellisense capabilities such as completions, validations and descriptions within JSON file configurations like the `tsup.config.json` and `package.json` (tsup) property.
 
 Provide the following configuration in your `.vscode/settings.json` (or global) settings file:
 
@@ -144,7 +144,7 @@ Provide the following configuration in your `.vscode/settings.json` (or global) 
 {
   "json.schemas": [
     {
-      "url": "https://unpkg.com/tsup/schema.json",
+      "url": "https://cdn.jsdelivr.net/npm/tsup/schema.json",
       "fileMatch": [
         "package.json",
         "tsup.config.json"

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
     <!-- Stylesheet -->
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@egoist/docup@2/dist/docup.min.css"
+      href="https://cdn.jsdelivr.net/npm/@egoist/docup@2/dist/docup.min.css"
     />
     <style>
       .logo-dark {
@@ -36,7 +36,7 @@
   </head>
   <body>
     <script type="module">
-      import * as docup from 'https://unpkg.com/@egoist/docup@2/dist/docup.min.js'
+      import * as docup from 'https://cdn.jsdelivr.net/npm/@egoist/docup@2/dist/docup.min.js'
       docup.init({
         // ..options
         navLinks: [


### PR DESCRIPTION
Unfortunately, the documentation site is not loading today because unpkg is down again.

See issues: 
- https://github.com/mjackson/unpkg/issues/352
- https://github.com/mjackson/unpkg/issues/343
- https://github.com/mjackson/unpkg/issues/338

