### PR TITLE
feat: support typescript 5.0 new syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postcss-simple-vars": "6.0.3",
     "prettier": "2.5.1",
     "resolve": "1.20.0",
-    "rollup-plugin-dts": "5.2.0",
+    "rollup-plugin-dts": "5.3.0",
     "rollup-plugin-hashbang": "2.2.2",
     "strip-json-comments": "4.0.0",
     "svelte": "3.46.4",
@@ -67,14 +67,14 @@
     "ts-essentials": "9.1.2",
     "tsconfig-paths": "3.12.0",
     "tsup": "6.6.1",
-    "typescript": "4.9.5",
+    "typescript": "5.0.2",
     "vitest": "0.28.4",
     "wait-for-expect": "3.0.2"
   },
   "peerDependencies": {
     "@swc/core": "^1",
     "postcss": "^8.4.12",
-    "typescript": "^4.1.0"
+    "typescript": ">=4.1.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ specifiers:
   resolve: 1.20.0
   resolve-from: ^5.0.0
   rollup: ^3.2.5
-  rollup-plugin-dts: 5.2.0
+  rollup-plugin-dts: 5.3.0
   rollup-plugin-hashbang: 2.2.2
   source-map: 0.8.0-beta.0
   strip-json-comments: 4.0.0
@@ -38,7 +38,7 @@ specifiers:
   ts-essentials: 9.1.2
   tsconfig-paths: 3.12.0
   tsup: 6.6.1
-  typescript: 4.9.5
+  typescript: 5.0.2
   vitest: 0.28.4
   wait-for-expect: 3.0.2
 
@@ -74,15 +74,15 @@ devDependencies:
   postcss-simple-vars: 6.0.3_postcss@8.4.12
   prettier: 2.5.1
   resolve: 1.20.0
-  rollup-plugin-dts: 5.2.0_4utlqqmr5inbj2sg4bq32gb67e
+  rollup-plugin-dts: 5.3.0_w45x5te3rgj5s4rm2f52x6cn5u
   rollup-plugin-hashbang: 2.2.2
   strip-json-comments: 4.0.0
   svelte: 3.46.4
   terser: 5.16.0
-  ts-essentials: 9.1.2_typescript@4.9.5
+  ts-essentials: 9.1.2_typescript@5.0.2
   tsconfig-paths: 3.12.0
-  tsup: 6.6.1_6lvfsmbcnhcbdgoh5cbwnen6ty
-  typescript: 4.9.5
+  tsup: 6.6.1_lsrxvfgknm7yoqug6axwee44ke
+  typescript: 5.0.2
   vitest: 0.28.4_terser@5.16.0
   wait-for-expect: 3.0.2
 
@@ -1335,8 +1335,8 @@ packages:
       vlq: 0.2.3
     dev: true
 
-  /magic-string/0.29.0:
-    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
+  /magic-string/0.30.0:
+    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -1583,16 +1583,16 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rollup-plugin-dts/5.2.0_4utlqqmr5inbj2sg4bq32gb67e:
-    resolution: {integrity: sha512-B68T/haEu2MKcz4kNUhXB8/h5sq4gpplHAJIYNHbh8cp4ZkvzDvNca/11KQdFrB9ZeKucegQIotzo5T0JUtM8w==}
+  /rollup-plugin-dts/5.3.0_w45x5te3rgj5s4rm2f52x6cn5u:
+    resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
       rollup: ^3.0.0
-      typescript: ^4.1
+      typescript: ^4.1 || ^5.0
     dependencies:
-      magic-string: 0.29.0
+      magic-string: 0.30.0
       rollup: 3.8.1
-      typescript: 4.9.5
+      typescript: 5.0.2
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
@@ -1801,12 +1801,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  /ts-essentials/9.1.2_typescript@4.9.5:
+  /ts-essentials/9.1.2_typescript@5.0.2:
     resolution: {integrity: sha512-EaSmXsAhEiirrTY1Oaa7TSpei9dzuCuFPmjKRJRPamERYtfaGS8/KpOSbjergLz/Y76/aZlV9i/krgzsuWEBbg==}
     peerDependencies:
       typescript: '>=4.1.0'
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.0.2
     dev: true
 
   /ts-interface-checker/0.1.13:
@@ -1821,7 +1821,7 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /tsup/6.6.1_6lvfsmbcnhcbdgoh5cbwnen6ty:
+  /tsup/6.6.1_lsrxvfgknm7yoqug6axwee44ke:
     resolution: {integrity: sha512-CtWqoZvZGVdwG8Hj0s+GhmBrr1zGVvuQNREfTn4Bl9NC3dMZV8CidYBIbKsrfZ8YPTDsjlxwtCVi72HppunzUA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -1853,7 +1853,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.20.3
       tree-kill: 1.2.2
-      typescript: 4.9.5
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -1864,9 +1864,9 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
Adds support for [TS 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0)'s new syntax, part of #858
This PR doesn't add support for [mentioning multiple files in `extends`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#supporting-multiple-configuration-files-in-extends), so #849 wouldn't get fixed by this

<details><summary>Testing</summary>
<p>

```ts
export function loggedMethod(originalMethod: any, _context: any) {

  function replacementMethod(this: any, ...args: any[]) {
      console.log("LOG: Entering method.")
      const result = originalMethod.call(this, ...args);
      console.log("LOG: Exiting method.")
      return result;
  }

  return replacementMethod;
}

export class Person {
  name: string;
  constructor(name: string) {
      this.name = name;
  }

  @loggedMethod
  greet() {
      console.log(`Hello, my name is ${this.name}.`);
  }
}

const p = new Person("Ray");
p.greet();

export type HasNames = { readonly names: string[] };
export function getNamesExactly<const T extends HasNames>(arg: T): T["names"] {
    return arg.names;
}

// Inferred type: readonly ["Alice", "Bob", "Eve"]
export const names = getNamesExactly({ names: ["Alice", "Bob", "Eve"]});
```
gets converted to

```js
"use strict";
var __defProp = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __getOwnPropNames = Object.getOwnPropertyNames;
var __hasOwnProp = Object.prototype.hasOwnProperty;
var __export = (target, all) => {
  for (var name in all)
    __defProp(target, name, { get: all[name], enumerable: true });
};
var __copyProps = (to, from, except, desc) => {
  if (from && typeof from === "object" || typeof from === "function") {
    for (let key of __getOwnPropNames(from))
      if (!__hasOwnProp.call(to, key) && key !== except)
        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
  }
  return to;
};
var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
var __decorateClass = (decorators, target, key, kind) => {
  var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target;
  for (var i = decorators.length - 1, decorator; i >= 0; i--)
    if (decorator = decorators[i])
      result = (kind ? decorator(target, key, result) : decorator(result)) || result;
  if (kind && result)
    __defProp(target, key, result);
  return result;
};

// testlo.ts
var testlo_exports = {};
__export(testlo_exports, {
  Person: () => Person,
  getNamesExactly: () => getNamesExactly,
  loggedMethod: () => loggedMethod,
  names: () => names
});
module.exports = __toCommonJS(testlo_exports);
function loggedMethod(originalMethod, _context) {
  function replacementMethod(...args) {
    console.log("LOG: Entering method.");
    const result = originalMethod.call(this, ...args);
    console.log("LOG: Exiting method.");
    return result;
  }
  return replacementMethod;
}
var Person = class {
  name;
  constructor(name) {
    this.name = name;
  }
  greet() {
    console.log(`Hello, my name is ${this.name}.`);
  }
};
__decorateClass([
  loggedMethod
], Person.prototype, "greet", 1);
var p = new Person("Ray");
p.greet();
function getNamesExactly(arg) {
  return arg.names;
}
var names = getNamesExactly({ names: ["Alice", "Bob", "Eve"] });
// Annotate the CommonJS export names for ESM import in node:
0 && (module.exports = {
  Person,
  getNamesExactly,
  loggedMethod,
  names
});
```
with the following `d.ts`:
```ts
declare function loggedMethod(originalMethod: any, _context: any): (this: any, ...args: any[]) => any;
declare class Person {
    name: string;
    constructor(name: string);
    greet(): void;
}
type HasNames = {
    readonly names: string[];
};
declare function getNamesExactly<const T extends HasNames>(arg: T): T["names"];
declare const names: string[];

export { HasNames, Person, getNamesExactly, loggedMethod, names };
```
`export type *` also works but it added a *lot* of types that would make this section harder to read

</p>
</details> 