### PR TITLE
refactor(options)!: type format as Format

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -115,7 +115,7 @@ export type Options = {
   jsxFragment?: string
   outDir?: string
   outExtension?: OutExtensionFactory
-  format?: Format[] | string
+  format?: Format[] | Format
   globalName?: string
   env?: {
     [k: string]: string


### PR DESCRIPTION
This types Options.format as `Format[] | Format` instead of `Format[] | string`.

You can currently pass in an array or string to `format`, however, the type is not consistent, as you are allowed to use the string literals from `Format` only for arrays, but not for strings. Typing it as `string` allows you to put anything as an option. This fixes that.
![image](https://user-images.githubusercontent.com/80943664/229475091-c094bb25-37e7-414e-bbb7-67ac9fc974fa.png)
![image](https://user-images.githubusercontent.com/80943664/229475184-e192930f-a691-4726-91f0-612e09206f6d.png)
