### PR TITLE
Remove SWC and Terser minification clash

### DIFF
--- a/src/plugins/es5.ts
+++ b/src/plugins/es5.ts
@@ -35,7 +35,7 @@ export const es5 = (): Plugin => {
           parser: {
             syntax: 'ecmascript',
           },
-          minify: this.options.minify ? {
+          minify: this.options.minify === true ? {
             compress: false,
             mangle: {
               reserved: this.options.globalName ? [this.options.globalName] : []


### PR DESCRIPTION
This PR fixes an issue when targeting `es5` and using `terser` for minification.

Currently when `minify === true` in `tsup` options, `SWC` will mangle the code. It leads to unexpected behavior, as you would believe that you have fine-grained control with `Terser`.