### PR TITLE
fix(external): match root paths on unix-like and windows

### DIFF
--- a/src/esbuild/external.ts
+++ b/src/esbuild/external.ts
@@ -1,8 +1,8 @@
 import { Plugin } from 'esbuild'
 import { tsconfigPathsToRegExp, match } from 'bundle-require'
 
-// Must not start with "/" or "./" or "../"
-const NON_NODE_MODULE_RE = /^[^.\/]|^\.[^.\/]|^\.\.[^\/]/
+// Must not start with "/" or "./" or "../" or "C:\" or be the exact strings ".." or "."
+const NON_NODE_MODULE_RE = /^[A-Z]:[\\\/]|^\.{0,2}[\/]|^\.{1,2}$/
 
 export const externalPlugin = ({
   external,
@@ -36,7 +36,7 @@ export const externalPlugin = ({
             return { external: true }
           }
           // Exclude any other import that looks like a Node module
-          if (NON_NODE_MODULE_RE.test(args.path)) {
+          if (!NON_NODE_MODULE_RE.test(args.path)) {
             return {
               path: args.path,
               external: true,


### PR DESCRIPTION
This PR fixes the regex used to match non node modules in the esbuild external plugin.

It changes the regex to match on the root of a windows-based filesystem in addition to simplifying the match of a unix-like root or relative path. 
This inverts the logic, however, I believe the regex was improperly named before, as what it was matching was actually node modules.

- By happenstance, this also fixes #879 and fixes #844.
- However, a more proper fix can be made if https://github.com/evanw/esbuild/issues/3079 gets implemented.