### PR TITLE
fix: #893

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -7,7 +7,7 @@ import {
   Plugin as EsbuildPlugin,
 } from 'esbuild'
 import { NormalizedOptions, Format } from '..'
-import { getProductionDeps, loadPkg } from '../load'
+import { getProductionDeps, loadJson, loadPkg } from '../load'
 import { Logger, getSilent } from '../log'
 import { nodeProtocolPlugin } from './node-protocol'
 import { externalPlugin } from './external'
@@ -182,6 +182,11 @@ export async function runEsbuild(
       : options.footer
 
   try {
+    const tsconfigData = await loadJson(options.tsconfig as string);
+    const targetFromJson = tsconfigData?.compilerOptions.target;
+    // If --target=es5/tsup.target=es5 take effect, read target from tsconfig
+    const target = options.es5TargetOutOfJson ? targetFromJson : options.target
+
     result = await esbuild({
       entryPoints: options.entry,
       format:
@@ -192,7 +197,7 @@ export async function runEsbuild(
       jsxFactory: options.jsxFactory,
       jsxFragment: options.jsxFragment,
       sourcemap: options.sourcemap ? 'external' : false,
-      target: options.target,
+      target,
       banner,
       footer,
       tsconfig: options.tsconfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,8 @@ const normalizeOptions = async (
     }
   }
 
+  options.es5TargetOutOfJson = options.target && options.target === 'es5';
+
   const tsconfig = loadTsConfig(process.cwd(), options.tsconfig)
   if (tsconfig) {
     logger.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,15 @@ const normalizeOptions = async (
     logger.info('CLI', `Building entry: ${JSON.stringify(entry)}`)
   }
 
+  // set tsconfig path from esbuildOptions function raw
+  if (!options.tsconfig && options.esbuildOptions) {
+    const regex = /(\w+)\.tsconfig\s*=\s*['"]([^'"]*)['"]/;
+    const match = options.esbuildOptions.toString().match(regex);
+    if (match) {
+      options.tsconfig = match[2];
+    }
+  }
+
   const tsconfig = loadTsConfig(process.cwd(), options.tsconfig)
   if (tsconfig) {
     logger.info(

--- a/src/load.ts
+++ b/src/load.ts
@@ -7,7 +7,7 @@ import { jsoncParse } from './utils'
 
 const joycon = new JoyCon()
 
-const loadJson = async (filepath: string) => {
+export const loadJson = async (filepath: string) => {
   try {
     return jsoncParse(await fs.promises.readFile(filepath, 'utf8'))
   } catch (error) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -100,6 +100,8 @@ export type Options = {
    * default to `node14`
    */
   target?: Target | Target[]
+  /** set es5 target from command line/tsup target property? */
+  es5TargetOutOfJson?: boolean;
   minify?: boolean | 'terser'
   terserOptions?: MinifyOptions
   minifyWhitespace?: boolean

--- a/src/plugins/es5.ts
+++ b/src/plugins/es5.ts
@@ -7,9 +7,8 @@ export const es5 = (): Plugin => {
   return {
     name: 'es5-target',
 
-    esbuildOptions(options) {
-      if (options.target === 'es5') {
-        // options.target = 'es2020'
+    esbuildOptions() {
+      if (this.options.es5TargetOutOfJson) {
         enabled = true
       }
     },

--- a/src/plugins/es5.ts
+++ b/src/plugins/es5.ts
@@ -9,7 +9,7 @@ export const es5 = (): Plugin => {
 
     esbuildOptions(options) {
       if (options.target === 'es5') {
-        options.target = 'es2020'
+        // options.target = 'es2020'
         enabled = true
       }
     },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1267,3 +1267,57 @@ test('custom inject style function', async () => {
   expect(await getFileContent('dist/input.mjs')).toContain('__custom_inject_style__(`.hello{color:red}\n`)')
   expect(await getFileContent('dist/input.js')).toContain('__custom_inject_style__(`.hello{color:red}\n`)')
 })
+
+test('set target by esbuildOptions', async () => {
+  await expect(
+    run(
+      getTestName(),
+      {
+        'input.ts': `const foo = 'foo';export default foo;`,
+        'tsup.config.ts': `export default {
+    esbuildOptions(options) {
+      options.tsconfig = 'custom.tsconfig.json';
+    },
+  }`,
+        'custom.tsconfig.json': `{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "esnext"
+    }
+  }`
+      },
+      {
+        flags: [
+          '--format',
+          'cjs',
+          // '--tsconfig',
+          // 'custom.tsconfig.json'
+        ],
+      }
+    )
+  ).rejects.toThrowError(
+    `Transforming const to the configured target environment ("es5") is not supported yet`
+  )
+})
+
+test('set target by default tsconfig.json', async () => {
+  await expect(
+    run(
+      getTestName(),
+      {
+        'input.ts': `const foo = 'foo';export default foo;`,
+        'tsconfig.json': `{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "esnext"
+    }
+  }`
+      },
+      {
+        flags: [ '--format', 'cjs' ],
+      }
+    )
+  ).rejects.toThrowError(
+    `Transforming const to the configured target environment ("es5") is not supported yet`
+  )
+})


### PR DESCRIPTION
Fixes #893 

- src\index.ts (line 102)

``` diff
+ // set tsconfig path from esbuildOptions function raw
+ if (!options.tsconfig && options.esbuildOptions) {
+   const regex = /(\w+)\.tsconfig\s*=\s*['"]([^'"]*)['"]/;
+   const match = options.esbuildOptions.toString().match(regex);
+   if (match) {
+     options.tsconfig = match[2];
+   }
+ }

const tsconfig = loadTsConfig(process.cwd(), options.tsconfig)
```

- src\plugins\es5.ts (line 12)

``` diff
    esbuildOptions(options) {
      if (options.target === 'es5') {
-       options.target = 'es2020'
+      // options.target = 'es2020'
        enabled = true
      }
    },
```

After the two, the test can pass (**But it conflict with the other 2 test cases !!!!!!**)

``` ts
test('set target by esbuildOptions', async () => {
  await expect(
    run(
      getTestName(),
      {
        'input.ts': `const foo = 'foo';export default foo;`,
        'tsup.config.ts': `export default {
    esbuildOptions(options) {
      options.tsconfig = 'custom.tsconfig.json';
    },
  }`,
        'custom.tsconfig.json': `{
    "compilerOptions": {
      "target": "es5",
      "module": "esnext"
    }
  }`
      },
      { flags: [ '--format',  'cjs' ] }
    )
  ).rejects.toThrowError(
    `Transforming const to the configured target environment ("es5") is not supported yet`
  )
})
```

**These got failed!!!!!!** (line 849). because I deleted the `options.target = 'es2020'`

This is a problem. @egoist 

``` ts
test('es5 target', async () => {
  const { output, outFiles } = await run(
    getTestName(),
    {
      'input.ts': `
    export class Foo {
      hi (): void {
        let a = () => 'foo'

        console.log(a())
      }
    }
    `,
    },
    {
      flags: ['--target', 'es5'],
    }
  )
  expect(output).toMatch(/createClass/)
  expect(outFiles).toEqual(['input.js'])
})
```
