### PR TITLE
fix: prefix terser log with name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ export async function build(_options: Options) {
                       minifyOptions: options.minify,
                       format,
                       terserOptions: options.terserOptions,
+                      logger,
                     }),
                   ])
                   await runEsbuild(options, {

--- a/src/plugins/terser.ts
+++ b/src/plugins/terser.ts
@@ -1,20 +1,20 @@
 import { MinifyOptions } from 'terser'
 import { PrettyError } from '../errors'
-import { createLogger } from '../log'
+import { Logger } from '../log'
 import { Format, Options } from '../options'
 import { Plugin } from '../plugin'
 import { localRequire } from '../utils'
-
-const logger = createLogger()
 
 export const terserPlugin = ({
   minifyOptions,
   format,
   terserOptions = {},
+  logger
 }: {
   minifyOptions: Options['minify']
   format: Format
-  terserOptions?: MinifyOptions
+  terserOptions?: MinifyOptions,
+  logger: Logger
 }): Plugin => {
   return {
     name: 'terser',


### PR DESCRIPTION
The terser log was not prefixed with name. This PR fixes that.

### before
```
[TSUP] CLI Building entry: src/cli-default.ts, src/cli-main.ts, src/cli-node.ts
[TSUP] CLI Using tsconfig: tsconfig.json
[TSUP] CLI tsup v0.0.0-semantic-release
[TSUP] CLI Using tsup config: C:\Users\green\Documents\GitHub\tsup\tsup.config.ts
[TSUP] CLI Target: node14
[TSUP] CJS Build start
TERSER Minifying with Terser
TERSER Terser Minification success
TERSER Minifying with Terser
TERSER Terser Minification success
TERSER Minifying with Terser
TERSER Terser Minification success
[TSUP] DTS Build start
[TSUP] CJS dist\cli-main.js    103.91 KB
[TSUP] CJS dist\cli-default.js 103.95 KB
[TSUP] CJS dist\cli-node.js    103.98 KB
[TSUP] CJS ⚡️ Build success in 1241ms
[TSUP] DTS ⚡️ Build success in 2368ms
[TSUP] DTS dist\index.d.ts 15.60 KB
```

### after
```
[TSUP] CLI Building entry: src/cli-default.ts, src/cli-main.ts, src/cli-node.ts
[TSUP] CLI Using tsconfig: tsconfig.json
[TSUP] CLI tsup v0.0.0-semantic-release
[TSUP] CLI Using tsup config: C:\Users\green\Documents\GitHub\tsup\tsup.config.ts
[TSUP] CLI Target: node14
[TSUP] CJS Build start
[TSUP] TERSER Minifying with Terser
[TSUP] TERSER Terser Minification success
[TSUP] TERSER Minifying with Terser
[TSUP] TERSER Terser Minification success
[TSUP] TERSER Minifying with Terser
[TSUP] TERSER Terser Minification success
[TSUP] DTS Build start
[TSUP] CJS dist\cli-default.js 103.94 KB
[TSUP] CJS dist\cli-main.js    103.90 KB
[TSUP] CJS dist\cli-node.js    103.96 KB
[TSUP] CJS ⚡️ Build success in 1269ms
[TSUP] DTS ⚡️ Build success in 2496ms
[TSUP] DTS dist\index.d.ts 15.60 KB
```
