### PR TITLE
fix: preserve top-level when running terser for IIFE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ export async function build(_options: Options) {
                       minifyOptions: options.minify,
                       format,
                       terserOptions: options.terserOptions,
+                      globalName: options.globalName,
                     }),
                   ])
                   await runEsbuild(options, {

--- a/src/plugins/terser.ts
+++ b/src/plugins/terser.ts
@@ -11,10 +11,12 @@ export const terserPlugin = ({
   minifyOptions,
   format,
   terserOptions = {},
+  globalName
 }: {
   minifyOptions: Options['minify']
   format: Format
-  terserOptions?: MinifyOptions
+  terserOptions?: MinifyOptions,
+  globalName?: string
 }): Plugin => {
   return {
     name: 'terser',
@@ -37,7 +39,7 @@ export const terserPlugin = ({
 
       if (format === 'esm') {
         defaultOptions.module = true
-      } else {
+      } else if (!(format === 'iife' && globalName !== undefined)) {
         defaultOptions.toplevel = true
       }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1267,3 +1267,18 @@ test('custom inject style function', async () => {
   expect(await getFileContent('dist/input.mjs')).toContain('__custom_inject_style__(`.hello{color:red}\n`)')
   expect(await getFileContent('dist/input.js')).toContain('__custom_inject_style__(`.hello{color:red}\n`)')
 })
+
+test('preserve top-level variable for IIFE format', async () => {
+  const { outFiles, getFileContent } = await run(getTestName(), {
+    'input.ts': `export default 'foo'`,
+    'tsup.config.ts': `
+        export default {
+          entry: ['src/input.ts'],
+          globalName: 'globalFoo',
+          minify: 'terser',
+          format: ['iife']
+        }`,
+  })
+  expect(outFiles).toEqual(['input.global.js'])
+  expect(await getFileContent('dist/input.global.js')).toMatch(/globalFoo\s*=/)
+})


### PR DESCRIPTION
When `globalName: 'globalFoo'` is set and the output format is `iife`, the output for the following input was not correct.
The variable `globalFoo` is not declared in the output.
```js
// input
export default 'foo'

// output (formatted)
'use strict'
;(() => {
  var e = Object.defineProperty,
    t = Object.getOwnPropertyDescriptor,
    r = Object.getOwnPropertyNames,
    o = Object.prototype.hasOwnProperty,
    a = {}
  ;((t, r) => {
    for (var o in r) e(t, o, { get: r[o], enumerable: !0 })
  })(a, { default: () => n })
  var f,
    n = 'foo'
  ;(f = a),
    ((a, f, n, c) => {
      if ((f && 'object' == typeof f) || 'function' == typeof f)
        for (let l of r(f))
          o.call(a, l) ||
            l === n ||
            e(a, l, {
              get: () => f[l],
              enumerable: !(c = t(f, l)) || c.enumerable,
            })
    })(e({}, '__esModule', { value: !0 }), f)
})()
```

This PR fixes this issue by avoid setting `toplevel: true` when the format is `iife` and `globalName` option is set.

```js
// new output (formatted)
'use strict'
var globalFoo = (() => {
  var e = Object.defineProperty,
    r = Object.getOwnPropertyDescriptor,
    t = Object.getOwnPropertyNames,
    o = Object.prototype.hasOwnProperty,
    a = {}
  ;((r, t) => {
    for (var o in t) e(r, o, { get: t[o], enumerable: !0 })
  })(a, { default: () => l })
  var n,
    l = 'foo'
  return (
    (n = a),
    ((a, n, l, f) => {
      if ((n && 'object' == typeof n) || 'function' == typeof n)
        for (let u of t(n))
          o.call(a, u) ||
            u === l ||
            e(a, u, {
              get: () => n[u],
              enumerable: !(f = r(n, u)) || f.enumerable,
            })
      return a
    })(e({}, '__esModule', { value: !0 }), n)
  )
})()
```
