### PR TITLE
Add `dtsOnly` to Options type

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -221,6 +221,10 @@ export type Options = {
    * Copy the files inside `publicDir` to output directory
    */
   publicDir?: string | boolean
+  /**
+   * Emit declaration file only
+   */
+  dtsOnly?: boolean;
 }
 
 export type NormalizedOptions = Omit<


### PR DESCRIPTION
When passing the `--dts-only` option to the CLI, the `options` contains a `dtsOnly` property, but it's not reflected in the type.