### PR TITLE
Clarify definition of custom output file names in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -162,7 +162,11 @@ Beside using positional arguments `tsup [...files]` to specify multiple entrypoi
 ```bash
 # Outputs `dist/a.js` and `dist/b.js`.
 tsup --entry src/a.ts --entry src/b.ts
+```
 
+The associated output file names can be defined as follows: 
+
+```bash
 # Outputs `dist/foo.js` and `dist/bar.js`.
 tsup --entry.foo src/a.ts --entry.bar src/b.ts
 ```


### PR DESCRIPTION
Making it a bit more obvious that the `--entry.*` parameter is intended to customize the output file names. 

(Ref. https://github.com/egoist/tsup/issues/447)