### PR TITLE
[DRAFT] feat: added logOverride option

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -257,6 +257,7 @@ export async function runEsbuild(
       write: false,
       splitting,
       logLevel: 'error',
+      logOverride: options.logOverride,
       minify: options.minify === 'terser' ? false : options.minify,
       minifyWhitespace: options.minifyWhitespace,
       minifyIdentifiers: options.minifyIdentifiers,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import type { BuildOptions, Plugin as EsbuildPlugin, Loader } from 'esbuild'
+import type { BuildOptions, Plugin as EsbuildPlugin, Loader, LogLevel } from 'esbuild'
 import type { InputOption } from 'rollup'
 import { MarkRequired } from 'ts-essentials'
 import type { Plugin } from './plugin'
@@ -221,6 +221,13 @@ export type Options = {
    * Copy the files inside `publicDir` to output directory
    */
   publicDir?: string | boolean
+
+  /**
+   * Change the log level of individual esbuild types of log messages.
+   * 
+   * @see https://esbuild.github.io/api/#log-override
+   */
+  logOverride?: Record<string, LogLevel>
 }
 
 export type NormalizedOptions = Omit<


### PR DESCRIPTION
This will fix #930

But currently esbuild is ignoring this setting and i cant find why it does it...

Example to reproduce

package.json

```json5
{
	...
	"type": "esm",
	...
}
```

tsup.config.ts

```ts
{
	...
	logOverride: {
        "package.json": "silent"
    },
	...
}
```

No warning should be shown after the log-override

More infos about this flag can be found on https://esbuild.github.io/api/#log-override