### PR TITLE
feat: add option for interop default in cjs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,15 +145,11 @@ Provide the following configuration in your `.vscode/settings.json` (or global) 
   "json.schemas": [
     {
       "url": "https://cdn.jsdelivr.net/npm/tsup/schema.json",
-      "fileMatch": [
-        "package.json",
-        "tsup.config.json"
-      ]
+      "fileMatch": ["package.json", "tsup.config.json"]
     }
   ]
 }
 ```
-
 
 ### Multiple entrypoints
 
@@ -164,7 +160,7 @@ Beside using positional arguments `tsup [...files]` to specify multiple entrypoi
 tsup --entry src/a.ts --entry src/b.ts
 ```
 
-The associated output file names can be defined as follows: 
+The associated output file names can be defined as follows:
 
 ```bash
 # Outputs `dist/foo.js` and `dist/bar.js`.
@@ -349,6 +345,14 @@ tsup src/index.ts --env.NODE_ENV production
 ### Building CLI app
 
 When an entry file like `src/cli.ts` contains hashbang like `#!/bin/env node` tsup will automatically make the output file executable, so you don't have to run `chmod +x dist/cli.js`.
+
+### Interop with CommonJS
+
+By default, esbuild will transform `export default x` to `module.exports.default = x` in CommonJS, but you can change this behavior by using the `--cjsInterop` flag: If there are only default exports and no named exports, it will be transformed to `module.exports = x` instead.
+
+```bash
+tsup src/index.ts --cjsInterop
+```
 
 ### Watch mode
 

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -95,6 +95,7 @@ export async function main(options: Options = {}) {
       '--killSignal <signal>',
       'Signal to kill child process, "SIGTERM" or "SIGKILL"'
     )
+    .option('--cjsInterop', 'Enable cjs interop')
     .action(async (files: string[], flags) => {
       const { build } = await import('.')
       Object.assign(options, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { sizeReporter } from './plugins/size-reporter'
 import { treeShakingPlugin } from './plugins/tree-shaking'
 import { copyPublicDir, isInPublicDir } from './lib/public-dir'
 import { terserPlugin } from './plugins/terser'
+import { cjsInterop } from './plugins/cjs-interop'
 
 export type { Format, Options, NormalizedOptions }
 
@@ -254,6 +255,7 @@ export async function build(_options: Options) {
                       silent: options.silent,
                     }),
                     cjsSplitting(),
+                    cjsInterop(),
                     es5(),
                     sizeReporter(),
                     terserPlugin({

--- a/src/options.ts
+++ b/src/options.ts
@@ -224,6 +224,10 @@ export type Options = {
    */
   publicDir?: string | boolean
   killSignal?: KILL_SIGNAL
+  /**
+   * Interop default within `module.exports` in cjs
+   * @default false
+   */
   cjsInterop?: boolean
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -224,6 +224,7 @@ export type Options = {
    */
   publicDir?: string | boolean
   killSignal?: KILL_SIGNAL
+  cjsInterop?: boolean
 }
 
 export type NormalizedOptions = Omit<

--- a/src/plugins/cjs-interop.ts
+++ b/src/plugins/cjs-interop.ts
@@ -1,0 +1,26 @@
+import { Plugin } from '../plugin'
+
+export const cjsInterop = (): Plugin => {
+  return {
+    name: 'cjs-interop',
+
+    async renderChunk(code, info) {
+      if (
+        !this.options.cjsInterop ||
+        this.format !== 'cjs' ||
+        info.type !== 'chunk' ||
+        !/\.(js|cjs)$/.test(info.path) ||
+        !info.entryPoint ||
+        info.exports?.length !== 1 ||
+        info.exports[0] !== 'default'
+      ) {
+        return
+      }
+
+      return {
+        code: code + '\nmodule.exports = exports.default',
+        map: info.map,
+      }
+    },
+  }
+}

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -145,8 +145,8 @@ const getRollupConfig = async (
         return
 
       return code.replace(
-        /(;|^)\s*export\s*{\s*([\w$]+)\s*as\s+default\s};?/,
-        (_, __, i) => `\nexport = ${i};`
+        /(?<=(?<=[;}]|^)\s*export\s*){\s*([\w$]+)\s*as\s+default\s*}/,
+        `= $1`
       )
     },
   }


### PR DESCRIPTION
## Description

Introduce a new option `cjsInterop`.

In the CJS file, if there's only an export default, then make it to `module.exports = _default`, instead of `module.exports = { default: _default }`.

For dts files, it will replace `export { _default as default }` with `export = _default`

### Usage

```ts
// before
const mod = require('something').default

// after
const mod = require('something')
```

## Relate issues

Closes #572

## Additional Information

It would be really helpful for removing [tons of post-build scripts](https://github.com/search?q=code+%2B%3D+%27exports.default+%3D+module.exports%3B%27&type=code).


`sucrase` also had an option [`enableLegacyBabel5ModuleInterop`](https://github.com/alangpierce/sucrase#legacy-commonjs-interop), with the same effect.
