### PR TITLE
fix: estarget should omit es3 which is not supported with swc or esbuild

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -63,7 +63,6 @@ export type BrowserTargetWithVersion =
   | `${BrowserTarget}${number}.${number}`
   | `${BrowserTarget}${number}.${number}.${number}`
 export type EsTarget =
-  | 'es3'
   | 'es5'
   | 'es6'
   | 'es2015'


### PR DESCRIPTION
Actally,the target is not supported with `swc` or `esbuild`. And if we set `target` with `es3` will get some error.
So `EsTarget` should omit `es3`