### PR TITLE
fix: add `neutral` value to platform options in `schema.json`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -326,7 +326,7 @@
           "description": "Target platform",
           "type": "string",
           "default": "node",
-          "enum": ["node", "browser"]
+          "enum": ["node", "browser", "neutral"]
         },
         "config": {
           "markdownDescription": "Disable config file with `false` or pass a custom config filename",


### PR DESCRIPTION
The `platform` configuration option allows for `node`, `browser`, and `neutral` ([source](https://github.com/egoist/tsup/blob/ec8301529bfc0d247c4e3037e5136f0a1871de82/src/options.ts#L184)).  This adds `neutral` as a valid option in the schema.json file, which was missing.