### PR TITLE
fix: add `terser` value to `minify` option in `schema.json`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -24,7 +24,6 @@
               }
             }
           ]
-
         }
       }
     },
@@ -99,8 +98,16 @@
           ]
         },
         "minify": {
-          "type": "boolean",
-          "description": "When enabled, the generated code will be minified instead of pretty-printed."
+          "description": "When enabled, the generated code will be minified instead of pretty-printed.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["terser"]
+            }
+          ]
         },
         "minifyWhitespace": {
           "type": "boolean"


### PR DESCRIPTION
Hi,

According to the docs at [https://paka.dev/npm/tsup@7.2.0/api#d35d54aca71eb26e](https://paka.dev/npm/tsup@7.2.0/api#d35d54aca71eb26e), the `minify` property should accept either a boolean or `"terser"` as a string.

While using tsup this in the last couple of days, I found that I was getting warnings in my config that `minify` expects a boolean.

I made a local copy of the whole schema file in my project and made the changes in this PR which solved the problem.

Thanks
D