### PR TITLE
Fix chmod error setting mode of DTS file that may not yet be written

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export async function build(_options: Options) {
               })
               worker.on('message', (data) => {
                 if (data === 'error') {
-                  reject(new Error('error occured in dts build'))
+                  reject(new Error('error occurred in dts build'))
                 } else if (data === 'success') {
                   resolve()
                 } else {

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -2,7 +2,6 @@ import { parentPort } from 'worker_threads'
 import { InputOptions, OutputOptions, Plugin } from 'rollup'
 import { NormalizedOptions } from './'
 import ts from 'typescript'
-import hashbangPlugin from 'rollup-plugin-hashbang'
 import jsonPlugin from '@rollup/plugin-json'
 import { handleError } from './errors'
 import { defaultOutExtension, removeFiles } from './utils'
@@ -167,7 +166,6 @@ const getRollupConfig = async (
       plugins: [
         tsupCleanPlugin,
         tsResolveOptions && tsResolvePlugin(tsResolveOptions),
-        hashbangPlugin(),
         jsonPlugin(),
         ignoreFiles,
         dtsPlugin.default({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -897,8 +897,6 @@ test('shebang ignores dts files', async () => {
     return
   }
 
-  console.log(`LOGS: ${logs}`)
-
   expect(() => {
     fs.accessSync(path.join(outDir, 'a.d.ts'), fs.constants.X_OK)
   }).toThrow()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -881,7 +881,7 @@ test('shebang', async () => {
  * which fails the build with an error:
  * https://github.com/egoist/tsup/issues/1001
  */
-test('shebang ignores dts files', async () => {
+test('do not chmod +x dts files', async () => {
   const { outDir, logs } = await run(
     getTestName(),
     {


### PR DESCRIPTION
Fixes #1001.

This removes rollup-plugin-hashbang from the configuration of Rollup that is used to generate DTS files. In theory, this plug-in is not needed for this build. rollup-plugin-hashbang remains in the configuration used when invoking Rollup to perform treeshaking.

The root cause of the issue may be inside rollup-plugin-hashbang, and a better fix might be possible there.

I have added a test to cover the issue being fixed, but it's possible this has broken something not covered by the existing tests.