### PR TITLE
fix(dts): ensure chunks conform to bundle format

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -207,6 +207,7 @@ const getRollupConfig = async (
         banner: dtsOptions.banner,
         footer: dtsOptions.footer,
         entryFileNames: `[name]${outputExtension}`,
+        chunkFileNames: `[name]-[hash]${outputExtension}`,
         plugins: [
           format === 'cjs' && options.cjsInterop && fixCjsExport,
         ].filter(Boolean),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1375,6 +1375,93 @@ test('should emit a declaration file per format (type: module)', async () => {
   ])
 })
 
+test('should emit dts chunks per format', async () => {
+  const { outFiles } = await run(
+    getTestName(),
+    {
+      'src/input1.ts': `
+          import type { InternalType } from './shared.js'
+
+          export function getValue(value: InternalType) {
+            return value;
+          }
+      `,
+      'src/input2.ts': `
+          import type { InternalType } from './shared.js'
+
+          export function getValue(value: InternalType) {
+            return value;
+          }
+      `,
+      'src/shared.ts': `export type InternalType = 'foo'`,
+      'tsup.config.ts': `
+        export default {
+          entry: ['./src/input1.ts', './src/input2.ts'],
+          format: ['esm', 'cjs'],
+          dts: true
+        }`,
+    },
+    { entry: [] }
+  )
+  expect(outFiles).toEqual([
+    'input1.d.mts',
+    'input1.d.ts',
+    'input1.js',
+    'input1.mjs',
+    'input2.d.mts',
+    'input2.d.ts',
+    'input2.js',
+    'input2.mjs',
+    'shared-qBqaX8Tr.d.mts',
+    'shared-qBqaX8Tr.d.ts',
+  ])
+})
+
+test('should emit dts chunks per format (type: module)', async () => {
+  const { outFiles } = await run(
+    getTestName(),
+    {
+      'src/input1.ts': `
+          import type { InternalType } from './shared.js'
+
+          export function getValue(value: InternalType) {
+            return value;
+          }
+      `,
+      'src/input2.ts': `
+          import type { InternalType } from './shared.js'
+
+          export function getValue(value: InternalType) {
+            return value;
+          }
+      `,
+      'src/shared.ts': `export type InternalType = 'foo'`,
+      'tsup.config.ts': `
+        export default {
+          entry: ['./src/input1.ts', './src/input2.ts'],
+          format: ['esm', 'cjs'],
+          dts: true
+        }`,
+      'package.json': `{
+          "type": "module"
+        }`,
+    },
+    { entry: [] }
+  )
+  expect(outFiles).toEqual([
+    'input1.cjs',
+    'input1.d.cts',
+    'input1.d.ts',
+    'input1.js',
+    'input2.cjs',
+    'input2.d.cts',
+    'input2.d.ts',
+    'input2.js',
+    'shared-qBqaX8Tr.d.cts',
+    'shared-qBqaX8Tr.d.ts',
+  ])
+})
+
 test('should emit declaration files with experimentalDts', async () => {
   const files = {
     'package.json': `


### PR DESCRIPTION
- Followup to https://github.com/egoist/tsup/pull/934

For runs with multiple entrypoints, there will sometimes be chunks generated.  Currently, the chunks generated *always* output .d.ts regardless of format, since that is rollup-plugin-dts's default. The prior PR fixed this for the main bundle output, but not these chunks.

In a lot of cases, this would be a non issue. However, in certain cases, a type is determined to be "internal" even though typescript can see through to the expected type. Because this file ends in `.ts`, it finds the nearest package.json to determine the module type (lets say cjs for this example). If this "internal" type is imported from another package with dual exports (say for something that's a peer dep), and then imported in application code that is another type (esm for this example), the same import is found in the two separate exports of said subpackage and may not be assignable to the same type. This is particularly noticeable with classes that have true private properties,