### PR TITLE
fix(experimental-dts): only include exported declarations

### DIFF
--- a/src/api-extractor.ts
+++ b/src/api-extractor.ts
@@ -123,9 +123,14 @@ async function rollupDtsFiles(
     sourceFileName = toAbsolutePath(sourceFileName)
     const outFileName = path.join(outDir, out + dtsExtension)
 
+    // Find all declarations that are exported from the current source file
+    const currentExports = exports.filter(
+      (declaration) => declaration.sourceFileName === sourceFileName
+    )
+
     writeFileSync(
       outFileName,
-      formatDistributionExports(exports, outFileName, dtsOutputFilePath)
+      formatDistributionExports(currentExports, outFileName, dtsOutputFilePath)
     )
   }
 }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -340,44 +340,22 @@ export { }
 // dist/index.d.mts
 //////////////////////////////////////////////////////////////////////
 
-export { render } from './_tsup-dts-rollup';
-export { ClientRenderOptions } from './_tsup-dts-rollup';
-export { sharedFunction } from './_tsup-dts-rollup';
-export { sharedType } from './_tsup-dts-rollup';
 export { VERSION } from './_tsup-dts-rollup';
-export { default_alias as default } from './_tsup-dts-rollup';
-export { ServerRenderOptions } from './_tsup-dts-rollup';
-export { serverConstant } from './_tsup-dts-rollup';
-export { serverConstantAlias } from './_tsup-dts-rollup';
-export { ServerClass } from './_tsup-dts-rollup';
-export { ServerThirdPartyNamespace } from './_tsup-dts-rollup';
-export { renderToString } from './_tsup-dts-rollup';
-export { renderToNodeStream } from './_tsup-dts-rollup';
-export { renderToStaticMarkup } from './_tsup-dts-rollup';
-export { renderToStaticNodeStream } from './_tsup-dts-rollup';
-export { version } from './_tsup-dts-rollup';
+export { render_alias_1 as render } from './_tsup-dts-rollup';
+export { ClientRenderOptions_alias_1 as ClientRenderOptions } from './_tsup-dts-rollup';
+export { sharedFunction_alias_1 as sharedFunction } from './_tsup-dts-rollup';
+export { sharedType_alias_1 as sharedType } from './_tsup-dts-rollup';
 
 
 //////////////////////////////////////////////////////////////////////
 // dist/index.d.ts
 //////////////////////////////////////////////////////////////////////
 
-export { render } from './_tsup-dts-rollup';
-export { ClientRenderOptions } from './_tsup-dts-rollup';
-export { sharedFunction } from './_tsup-dts-rollup';
-export { sharedType } from './_tsup-dts-rollup';
 export { VERSION } from './_tsup-dts-rollup';
-export { default_alias as default } from './_tsup-dts-rollup';
-export { ServerRenderOptions } from './_tsup-dts-rollup';
-export { serverConstant } from './_tsup-dts-rollup';
-export { serverConstantAlias } from './_tsup-dts-rollup';
-export { ServerClass } from './_tsup-dts-rollup';
-export { ServerThirdPartyNamespace } from './_tsup-dts-rollup';
-export { renderToString } from './_tsup-dts-rollup';
-export { renderToNodeStream } from './_tsup-dts-rollup';
-export { renderToStaticMarkup } from './_tsup-dts-rollup';
-export { renderToStaticNodeStream } from './_tsup-dts-rollup';
-export { version } from './_tsup-dts-rollup';
+export { render_alias_1 as render } from './_tsup-dts-rollup';
+export { ClientRenderOptions_alias_1 as ClientRenderOptions } from './_tsup-dts-rollup';
+export { sharedFunction_alias_1 as sharedFunction } from './_tsup-dts-rollup';
+export { sharedType_alias_1 as sharedType } from './_tsup-dts-rollup';
 
 
 //////////////////////////////////////////////////////////////////////
@@ -388,18 +366,6 @@ export { render } from './_tsup-dts-rollup';
 export { ClientRenderOptions } from './_tsup-dts-rollup';
 export { sharedFunction } from './_tsup-dts-rollup';
 export { sharedType } from './_tsup-dts-rollup';
-export { VERSION } from './_tsup-dts-rollup';
-export { default_alias as default } from './_tsup-dts-rollup';
-export { ServerRenderOptions } from './_tsup-dts-rollup';
-export { serverConstant } from './_tsup-dts-rollup';
-export { serverConstantAlias } from './_tsup-dts-rollup';
-export { ServerClass } from './_tsup-dts-rollup';
-export { ServerThirdPartyNamespace } from './_tsup-dts-rollup';
-export { renderToString } from './_tsup-dts-rollup';
-export { renderToNodeStream } from './_tsup-dts-rollup';
-export { renderToStaticMarkup } from './_tsup-dts-rollup';
-export { renderToStaticNodeStream } from './_tsup-dts-rollup';
-export { version } from './_tsup-dts-rollup';
 
 
 //////////////////////////////////////////////////////////////////////
@@ -410,35 +376,21 @@ export { render } from './_tsup-dts-rollup';
 export { ClientRenderOptions } from './_tsup-dts-rollup';
 export { sharedFunction } from './_tsup-dts-rollup';
 export { sharedType } from './_tsup-dts-rollup';
-export { VERSION } from './_tsup-dts-rollup';
-export { default_alias as default } from './_tsup-dts-rollup';
-export { ServerRenderOptions } from './_tsup-dts-rollup';
-export { serverConstant } from './_tsup-dts-rollup';
-export { serverConstantAlias } from './_tsup-dts-rollup';
-export { ServerClass } from './_tsup-dts-rollup';
-export { ServerThirdPartyNamespace } from './_tsup-dts-rollup';
-export { renderToString } from './_tsup-dts-rollup';
-export { renderToNodeStream } from './_tsup-dts-rollup';
-export { renderToStaticMarkup } from './_tsup-dts-rollup';
-export { renderToStaticNodeStream } from './_tsup-dts-rollup';
-export { version } from './_tsup-dts-rollup';
 
 
 //////////////////////////////////////////////////////////////////////
 // dist/server/index.d.mts
 //////////////////////////////////////////////////////////////////////
 
-export { render } from '../_tsup-dts-rollup';
-export { ClientRenderOptions } from '../_tsup-dts-rollup';
-export { sharedFunction } from '../_tsup-dts-rollup';
-export { sharedType } from '../_tsup-dts-rollup';
-export { VERSION } from '../_tsup-dts-rollup';
+export { render_alias_2 as render } from '../_tsup-dts-rollup';
 export { default_alias as default } from '../_tsup-dts-rollup';
 export { ServerRenderOptions } from '../_tsup-dts-rollup';
 export { serverConstant } from '../_tsup-dts-rollup';
 export { serverConstantAlias } from '../_tsup-dts-rollup';
 export { ServerClass } from '../_tsup-dts-rollup';
 export { ServerThirdPartyNamespace } from '../_tsup-dts-rollup';
+export { sharedFunction_alias_2 as sharedFunction } from '../_tsup-dts-rollup';
+export { sharedType_alias_2 as sharedType } from '../_tsup-dts-rollup';
 export { renderToString } from '../_tsup-dts-rollup';
 export { renderToNodeStream } from '../_tsup-dts-rollup';
 export { renderToStaticMarkup } from '../_tsup-dts-rollup';
@@ -450,17 +402,15 @@ export { version } from '../_tsup-dts-rollup';
 // dist/server/index.d.ts
 //////////////////////////////////////////////////////////////////////
 
-export { render } from '../_tsup-dts-rollup';
-export { ClientRenderOptions } from '../_tsup-dts-rollup';
-export { sharedFunction } from '../_tsup-dts-rollup';
-export { sharedType } from '../_tsup-dts-rollup';
-export { VERSION } from '../_tsup-dts-rollup';
+export { render_alias_2 as render } from '../_tsup-dts-rollup';
 export { default_alias as default } from '../_tsup-dts-rollup';
 export { ServerRenderOptions } from '../_tsup-dts-rollup';
 export { serverConstant } from '../_tsup-dts-rollup';
 export { serverConstantAlias } from '../_tsup-dts-rollup';
 export { ServerClass } from '../_tsup-dts-rollup';
 export { ServerThirdPartyNamespace } from '../_tsup-dts-rollup';
+export { sharedFunction_alias_2 as sharedFunction } from '../_tsup-dts-rollup';
+export { sharedType_alias_2 as sharedType } from '../_tsup-dts-rollup';
 export { renderToString } from '../_tsup-dts-rollup';
 export { renderToNodeStream } from '../_tsup-dts-rollup';
 export { renderToStaticMarkup } from '../_tsup-dts-rollup';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1633,3 +1633,67 @@ test('should emit declaration files with experimentalDts', async () => {
   )
   expect(snapshots.sort().join('\n')).toMatchSnapshot()
 })
+
+test('should only include exported declarations with experimentalDts', async () => {
+  const files = {
+    'package.json': `
+        {
+          "name": "tsup-playground",
+          "private": true,
+          "version": "0.0.0",
+          "exports": {
+              "./entry1": {
+                  "types": "./dist/entry1.d.ts",
+                  "default": "./dist/entry1.js"
+              },
+              "./entry2": {
+                  "types": "./dist/entry2.d.ts",
+                  "default": "./dist/entry2.js"
+              }
+          }
+        }
+    `,
+    'tsconfig.json': `
+        {
+          "compilerOptions": {
+              "target": "ES2020",
+              "skipLibCheck": true,
+              "noEmit": true
+          },
+          "include": ["./src"]
+        }
+    `,
+    'tsup.config.ts': `
+        export default {
+          name: 'tsup',
+          entry: {
+            'entry1': './src/entry1.ts',
+            'entry2': './src/entry2.ts',
+          },
+        }
+    `,
+    'src/shared.ts': `
+        export const declare1 = 'declare1'
+        export const declare2 = 'declare2'
+    `,
+    'src/entry1.ts': `
+        export { declare1 } from './shared'
+    `,
+    'src/entry2.ts': `
+        export { declare2 } from './shared'
+    `,
+  }
+  const {  getFileContent } = await run(getTestName(), files, {
+    entry: [],
+    flags: ['--experimental-dts'],
+  })
+
+  let entry1dts = await getFileContent('dist/entry1.d.ts')
+  let entry2dts = await getFileContent('dist/entry2.d.ts')
+
+  expect(entry1dts).toContain('declare1')
+  expect(entry1dts).not.toContain('declare2')
+
+  expect(entry2dts).toContain('declare2')
+  expect(entry2dts).not.toContain('declare1')
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1636,40 +1636,11 @@ test('should emit declaration files with experimentalDts', async () => {
 
 test('should only include exported declarations with experimentalDts', async () => {
   const files = {
-    'package.json': `
-        {
-          "name": "tsup-playground",
-          "private": true,
-          "version": "0.0.0",
-          "exports": {
-              "./entry1": {
-                  "types": "./dist/entry1.d.ts",
-                  "default": "./dist/entry1.js"
-              },
-              "./entry2": {
-                  "types": "./dist/entry2.d.ts",
-                  "default": "./dist/entry2.js"
-              }
-          }
-        }
-    `,
-    'tsconfig.json': `
-        {
-          "compilerOptions": {
-              "target": "ES2020",
-              "skipLibCheck": true,
-              "noEmit": true
-          },
-          "include": ["./src"]
-        }
-    `,
+    'package.json': `{ "name": "tsup-playground", "private": true }`,
+    'tsconfig.json': `{ "compilerOptions": { "skipLibCheck": true } }`,
     'tsup.config.ts': `
         export default {
-          name: 'tsup',
-          entry: {
-            'entry1': './src/entry1.ts',
-            'entry2': './src/entry2.ts',
-          },
+          entry: ['./src/entry1.ts', './src/entry2.ts']
         }
     `,
     'src/shared.ts': `

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1683,7 +1683,7 @@ test('should only include exported declarations with experimentalDts', async () 
         export { declare2 } from './shared'
     `,
   }
-  const {  getFileContent } = await run(getTestName(), files, {
+  const { getFileContent } = await run(getTestName(), files, {
     entry: [],
     flags: ['--experimental-dts'],
   })


### PR DESCRIPTION
This PR fixes a bug when using the `--experimental-dts`.

Let's say we have the following file structure:

```
// src/shared.ts
export const declare1 = 'declare1'
export const declare2 = 'declare2'

// src/entry1.ts
export { declare1 } from './shared'

// src/entry2.ts
export { declare2 } from './shared'
```

In this example, `entry1.ts` and `entry2.ts` are public entry files. In the generated `entry1.d.ts`, it should only contain `declare1`, and `entry2.d.ts` should only contain `declare2`. However, the generated `entry1.d.ts` and `entry2.d.ts` incorrectly contain both `declare1` and `declare2`.

This PR fixes this bug and adds a test case.