### PR TITLE
fix: outExtension for generating dts files by rollup

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -256,4 +256,6 @@ export type NormalizedOptions = Omit<
   tsconfigResolvePaths: Record<string, string[]>
   tsconfigDecoratorMetadata?: boolean
   format: Format[]
+  // OutExtensionObject array for each format
+  formatOutExtension: OutExtensionObject[]
 }

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -154,9 +154,9 @@ const getRollupConfig = async (
         ...(options.external || []),
       ],
     },
-    outputConfig: options.format.map((format): OutputOptions => {
-      const outputExtension =
-        options.outExtension?.({ format, options, pkgType: pkg.type }).dts ||
+    outputConfig: options.format.map((format, i): OutputOptions => {
+      const outputExtension = 
+        options.formatOutExtension?.[i]?.dts ||
         defaultOutExtension({ format, pkgType: pkg.type }).dts
       return {
         dir: options.outDir || 'dist',


### PR DESCRIPTION
The problem:
- https://github.com/egoist/tsup/issues/939
- https://github.com/egoist/tsup/issues/667

Description:
Rollup operates in a Node.js [Worker threads](https://nodejs.org/api/worker_threads.html) and can only receive messages as plain objects (without functions). In `tsup.config`, outExtension is a function. Therefore if we send the config "as is", we encounter a [DataCloneError](https://github.com/egoist/tsup/issues/667).

Solution:
Execute `outExtension` before sending message to rollup worker thread and send the array with `outExtension` results.