### PR TITLE
feat: add cjsInterop support without splitting flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/egoist/tsup.git"
   },
   "scripts": {
-    "dev": "npm run build-fast -- --watch",
+    "dev": "npm run build-fast -- --sourcemap --watch",
     "build": "tsup src/cli-*.ts src/index.ts src/rollup.ts --clean --splitting",
     "prepublishOnly": "npm run build",
     "test": "npm run build && npm run test-only",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,7 +4,7 @@ import { SourceMapConsumer, SourceMapGenerator, RawSourceMap } from 'source-map'
 import { Format, NormalizedOptions } from '.'
 import { outputFile } from './fs'
 import { Logger } from './log'
-import { MaybePromise } from './utils'
+import { MaybePromise, slash } from './utils'
 import { SourceMap } from 'rollup'
 
 export type ChunkInfo = {
@@ -124,7 +124,8 @@ export class PluginContainer {
       .filter((file) => !file.path.endsWith('.map'))
       .map((file): ChunkInfo | AssetInfo => {
         if (isJS(file.path) || isCSS(file.path)) {
-          const relativePath = path.relative(process.cwd(), file.path)
+          // esbuild is using "/" as a separator in Windows as well
+          const relativePath = slash(path.relative(process.cwd(), file.path))
           const meta = metafile?.outputs[relativePath]
           return {
             type: 'chunk',

--- a/src/plugins/cjs-interop.ts
+++ b/src/plugins/cjs-interop.ts
@@ -1,26 +1,114 @@
+import type {
+  ExportDefaultExpression,
+  ModuleDeclaration,
+  ParseOptions,
+} from '@swc/core'
+import type { Visitor } from '@swc/core/Visitor'
+import fs from 'fs/promises'
+import path from 'path'
+import { PrettyError } from '../errors'
 import { Plugin } from '../plugin'
+import { localRequire } from '../utils'
 
 export const cjsInterop = (): Plugin => {
   return {
     name: 'cjs-interop',
 
     async renderChunk(code, info) {
+      const { entryPoint } = info
       if (
         !this.options.cjsInterop ||
         this.format !== 'cjs' ||
         info.type !== 'chunk' ||
         !/\.(js|cjs)$/.test(info.path) ||
-        !info.entryPoint ||
-        info.exports?.length !== 1 ||
-        info.exports[0] !== 'default'
+        !entryPoint
       ) {
         return
       }
 
+      if (this.splitting) {
+        // there is exports metadata when cjs+splitting is set
+        if (info.exports?.length !== 1 || info.exports[0] !== 'default') return
+      } else {
+        const swc: typeof import('@swc/core') = localRequire('@swc/core')
+        const { Visitor }: typeof import('@swc/core/Visitor') =
+          localRequire('@swc/core/Visitor')
+        if (!swc || !Visitor) {
+          throw new PrettyError(
+            `@swc/core is required for cjsInterop when splitting is not enabled. Please install it with \`npm install @swc/core -D\``
+          )
+        }
+
+        try {
+          const entrySource = await fs.readFile(entryPoint, {
+            encoding: 'utf8',
+          })
+          const parseOptions = getParseOptions(entryPoint)
+          if (!parseOptions) return
+          const ast = await swc.parse(entrySource, parseOptions)
+          const visitor = createExportVisitor(Visitor)
+          visitor.visitProgram(ast)
+
+          if (
+            !visitor.hasExportDefaultExpression ||
+            visitor.hasNonDefaultExportDeclaration
+          )
+            return
+        } catch {
+          return
+        }
+      }
+
       return {
-        code: code + '\nmodule.exports = exports.default;\n',
+        code: code + '\nmodule.exports=module.exports.default;\n',
         map: info.map,
       }
     },
   }
+}
+
+function getParseOptions(filename: string): ParseOptions | null {
+  if (/\.([cm]?js|jsx)$/.test(filename))
+    return {
+      syntax: 'ecmascript',
+      decorators: true,
+      jsx: filename.endsWith('.jsx'),
+    }
+  if (/\.([cm]?ts|tsx)$/.test(filename))
+    return {
+      syntax: 'typescript',
+      decorators: true,
+      tsx: filename.endsWith('.tsx'),
+    }
+  return null
+}
+
+function createExportVisitor(VisitorCtor: typeof Visitor) {
+  class ExportVisitor extends VisitorCtor {
+    hasNonDefaultExportDeclaration = false
+    hasExportDefaultExpression = false
+    constructor() {
+      super()
+      type ExtractDeclName<T> = T extends `visit${infer N}` ? N : never
+      const nonDefaultExportDecls: ExtractDeclName<keyof Visitor>[] = [
+        'ExportDeclaration', // export const a = {}
+        'ExportNamedDeclaration', // export {}, export * as a from './a'
+        'ExportAllDeclaration', // export * from './a'
+      ]
+
+      nonDefaultExportDecls.forEach((decl) => {
+        this[`visit${decl}`] = (n: any) => {
+          this.hasNonDefaultExportDeclaration = true
+          return n
+        }
+      })
+    }
+    visitExportDefaultExpression(
+      n: ExportDefaultExpression
+    ): ModuleDeclaration {
+      this.hasExportDefaultExpression = true
+      return n
+    }
+  }
+  return new ExportVisitor()
 }


### PR DESCRIPTION
esbuild does not provide an exports metadata when the format is `cjs`.

`splitting` is working because it's also bundled as esm
https://github.com/egoist/tsup/blob/fb4c2b6e75e29c58956eaaa6afab12b130accb14/src/esbuild/index.ts#L164-L165
and then transformed to cjs:
https://github.com/egoist/tsup/blob/7000c8b6f5e69b801754a1846844cfc966f84571/src/plugins/cjs-splitting.ts#L21-L31