### PR TITLE
fix: correct sourcemap with treeshake

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -168,9 +168,8 @@ export class PluginContainer {
                 const newConsumer = await new SourceMapConsumer(
                   parseSourceMap(result.map),
                 )
-                const generator =
-                  SourceMapGenerator.fromSourceMap(originalConsumer)
-                generator.applySourceMap(newConsumer, info.path)
+                const generator = SourceMapGenerator.fromSourceMap(newConsumer)
+                generator.applySourceMap(originalConsumer, info.path)
                 info.map = generator.toJSON()
                 originalConsumer.destroy()
                 newConsumer.destroy()

--- a/src/plugins/tree-shaking.ts
+++ b/src/plugins/tree-shaking.ts
@@ -32,7 +32,7 @@ export const treeShakingPlugin = ({
               return false
             },
             load(id) {
-              if (id === info.path) return code
+              if (id === info.path) return { code, map: info.map }
             },
           },
         ],

--- a/src/plugins/tree-shaking.ts
+++ b/src/plugins/tree-shaking.ts
@@ -1,5 +1,6 @@
 import { rollup, type TreeshakingOptions, type TreeshakingPreset } from 'rollup'
 import type { Plugin } from '../plugin'
+import path from 'path'
 
 export type TreeshakingStrategy =
   | boolean
@@ -44,14 +45,14 @@ export const treeShakingPlugin = ({
       const result = await bundle.generate({
         interop: 'auto',
         format: this.format,
-        file: 'out.js',
+        file: info.path,
         sourcemap: !!this.options.sourcemap,
         name,
       })
 
       for (const file of result.output) {
         if (file.type === 'chunk') {
-          if (file.fileName.endsWith('out.js')) {
+          if (file.fileName === path.basename(info.path)) {
             return {
               code: file.code,
               map: file.map,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -858,10 +858,11 @@ test('should load postcss esm config', async () => {
 })
 
 test('generate sourcemap with --treeshake', async () => {
+  const sourceCode = 'export function getValue(val: any){ return val; }'
   const { outFiles, getFileContent } = await run(
     getTestName(),
     {
-      'src/input.ts': 'export function getValue(val: any){ return val; }',
+      'src/input.ts': sourceCode,
     },
     {
       entry: ['src/input.ts'],
@@ -880,9 +881,7 @@ test('generate sourcemap with --treeshake', async () => {
         )
 
         expect(sourceMap.sources[0]).toBe('../src/input.ts')
-        expect(sourceMap.sourcesContent[0]).toBe(
-          'export function getValue(val: any){ return val; }',
-        )
+        expect(sourceMap.sourcesContent[0]).toBe(sourceCode)
 
         const outputFileName = sourceMapFile.replace('.map', '')
         expect(sourceMap.file).toBe(outputFileName)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -856,3 +856,36 @@ test('should load postcss esm config', async () => {
   expect(outFiles).toEqual(['input.cjs', 'input.css'])
   expect(await getFileContent('dist/input.css')).toContain('color: blue;')
 })
+
+test('generate sourcemap with --treeshake', async () => {
+  const { outFiles, getFileContent } = await run(
+    getTestName(),
+    {
+      'src/input.ts': 'export function getValue(val: any){ return val; }',
+    },
+    {
+      entry: ['src/input.ts'],
+      flags: ['--treeshake', '--sourcemap', '--format=cjs,esm,iife'],
+    },
+  )
+
+  expect(outFiles.length).toBe(6)
+
+  await Promise.all(
+    outFiles
+      .filter((fileName) => fileName.endsWith('.map'))
+      .map(async (sourceMapFile) => {
+        const sourceMap = await getFileContent(`dist/${sourceMapFile}`).then(
+          (rawContent) => JSON.parse(rawContent),
+        )
+
+        expect(sourceMap.sources[0]).toBe('../src/input.ts')
+        expect(sourceMap.sourcesContent[0]).toBe(
+          'export function getValue(val: any){ return val; }',
+        )
+
+        const outputFileName = sourceMapFile.replace('.map', '')
+        expect(sourceMap.file).toBe(outputFileName)
+      }),
+  )
+})


### PR DESCRIPTION
depends on pr https://github.com/egoist/tsup/pull/890

related to issue https://github.com/egoist/tsup/issues/889#issuecomment-1871297831

1. fix incorrect use of `applySourceMap()`
correct example: https://github.com/mozilla/source-map/blob/master/test/test-source-map-generator.js#L356-L362

2. set rollup treeshake output path to `./dist`, so that `sources` in sourcemap can refer to `../src/index.ts` instead of `src/index.ts`


closes #890, closes #889