### PR TITLE
fix: support swc target for mjs

### DIFF
--- a/src/plugins/swc-target.ts
+++ b/src/plugins/swc-target.ts
@@ -1,3 +1,4 @@
+import type { ModuleConfig } from '@swc/core/types';
 import { PrettyError } from '../errors'
 import { Plugin } from '../plugin'
 import { localRequire } from '../utils'
@@ -23,7 +24,7 @@ export const swcTarget = (): Plugin => {
     },
 
     async renderChunk(code, info) {
-      if (!enabled || !/\.(cjs|js)$/.test(info.path) || this.format !== 'cjs') {
+      if (!enabled || !/\.(cjs|mjs|js)$/.test(info.path)) {
         return
       }
       const swc: typeof import('@swc/core') = localRequire('@swc/core')
@@ -55,6 +56,9 @@ export const swcTarget = (): Plugin => {
                 }
               : undefined,
         },
+        module: {
+          type: this.format === 'cjs' ? 'commonjs' : 'es6'
+        } as ModuleConfig,
       })
       return {
         code: result.code,


### PR DESCRIPTION
If it is mjs, it is not included in the swcTarget even if I set it as an ES5 target.
I think the reason for the exclusion of mjs is that if the browser supports import, it is guaranteed to run ES6 or later code.
However, if you use a process like the one below, you'll run into problems.

- generate cjs, mjs code for target: es5 with tsup and publish it as a package named foo.
- a project named bar installs and uses the foo package. This project is set "type": "module".
- the bar project has imported the foo package.
- the bar project runs with ESM, it reads foo/index.mjs.
- when we build the bar project, the foo package is in node_modules, so it won't run in older browsers unless we transpile it further.

In addition to this issue, I think it's also a problem that tsup's target is set to ES5 and it doesn't transpile as expected.
So I've included MJS as well to solve this problem.