### PR TITLE
fix: wider restriction for `target` option

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -85,7 +85,7 @@ export type EsTarget =
   | 'es2022'
   | 'esnext'
 
-export type Target = BrowserTarget | BrowserTargetWithVersion | EsTarget
+export type Target = BrowserTarget | BrowserTargetWithVersion | EsTarget | (string & {})
 
 export type Entry = string[] | Record<string, string>
 


### PR DESCRIPTION
fix https://github.com/egoist/tsup/issues/1111