### PR TITLE
pass config to postcss

### DIFF
--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -24,9 +24,12 @@ export const postcssPlugin = ({
         if (configCache) {
           return configCache
         }
+        const postCssCtx = {
+          tsupOptions: build.initialOptions
+        }
 
         try {
-          const result = await loadConfig({}, process.cwd())
+          const result = await loadConfig(postCssCtx, process.cwd())
           configCache = result
           return result
         } catch (error: any) {


### PR DESCRIPTION
passing config to postcss to allow postcss config file to utilize it. in my use case I need to build dynamic tailwindcss config. 