### PR TITLE
fix: Replace parentPort.close() with process.exit() in worker thread

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -240,7 +240,7 @@ const startRollup = async (options: NormalizedOptions) => {
     } catch (error) {
       parentPort?.postMessage('error')
     }
-    parentPort?.close()
+    process.exit()
   }
 }
 


### PR DESCRIPTION
This change ensures the worker thread signals the parent process to exit in the bun runtime environment. Previously, the parent process would continue running indefinitely due to an unclear issue with worker thread termination. This fix ensures a clean exit after the worker thread has completed its tasks.

**Context:**

This bug stops us from fully migrating to the bun runtime for the Storybook mono repo without additional workarounds.

**Reproduction:**

Run tsup programmatically in a bun runtime instead of Node.js and define some DTS options so that the rollup worker thread spawns. With this fix, after building the DTS assets, the process exits successfully. Before, the process never exited.

