### PR TITLE
Fix bug related to `verbatimModuleSyntax` in v8.1.1

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,8 +63,6 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-
-    "verbatimModuleSyntax": true
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
## **This PR**:

- [X] Fixes bug related to `verbatimModuleSyntax` in v8.1.1. With `verbatimModuleSyntax` enabled, we receive `Cannot find module '@swc/core'` error which will go away if we disable `verbatimModuleSyntax`.
- [X] Resolves #1157.