### PR TITLE
docs: update tsup API docs link [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This will output `dist/index.js` and `dist/cli.js`.
 
 For complete usages, please dive into the [docs](https://tsup.egoist.dev).
 
-For all configuration options, please see [the API docs](https://paka.dev/npm/tsup#module-index-export-Options).
+For all configuration options, please see [the API docs](https://jsdocs.io/package/tsup).
 
 ## 💬 Discussions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ You can use any of these files:
 
 You can also specify a custom filename using the `--config` flag, or passing `--no-config` to disable config files.
 
-[Check out all available options](https://paka.dev/npm/tsup#module-index-export-Options).
+[Check out all available options](https://jsdocs.io/package/tsup).
 
 #### TypeScript / JavaScript
 
@@ -595,7 +595,7 @@ await build({
 })
 ```
 
-For all available options for the `build` function, please see [the API docs](https://paka.dev/npm/tsup).
+For all available options for the `build` function, please see [the API docs](https://jsdocs.io/package/tsup).
 
 ### Using custom tsconfig.json
 


### PR DESCRIPTION
The API docs link in the README.md file has been updated to point to [jsdocs.io](https://jsdocs.io/package/tsup) for all configuration opt