### PR TITLE
feat: add `sourceRoot` option

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -224,6 +224,9 @@
             }
           ]
         },
+        "sourceRoot": {
+          "type": "string"
+        },
         "noExternal": {
           "type": "array",
           "items": {

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -47,6 +47,10 @@ export async function main(options: Options = {}) {
       'Generate external sourcemap, or inline source: --sourcemap inline',
     )
     .option(
+      '--sourceRoot [path]',
+      'Specify the location where a debugger should locate TypeScript files instead of relative source locations',
+    )
+    .option(
       '--watch [path]',
       'Watch mode, if path is not specified, it watches the current folder ".". Repeat "--watch" for more than one path',
     )

--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -169,6 +169,7 @@ export async function runEsbuild(
       jsxFactory: options.jsxFactory,
       jsxFragment: options.jsxFragment,
       sourcemap: options.sourcemap ? 'external' : false,
+      sourceRoot: options.sourceRoot,
       target: options.target,
       banner,
       footer,

--- a/src/options.ts
+++ b/src/options.ts
@@ -137,6 +137,7 @@ export type Options = {
   dts?: boolean | string | DtsConfig
   experimentalDts?: boolean | string | ExperimentalDtsConfig
   sourcemap?: boolean | 'inline'
+  sourceRoot?: string
   /** Always bundle modules matching given patterns */
   noExternal?: (string | RegExp)[]
   /** Don't bundle these modules */

--- a/src/plugins/swc-target.ts
+++ b/src/plugins/swc-target.ts
@@ -38,6 +38,7 @@ export const swcTarget = (): Plugin => {
       const result = await swc.transform(code, {
         filename: info.path,
         sourceMaps: this.options.sourcemap,
+        sourceRoot: this.options.sourceRoot,
         minify: Boolean(this.options.minify),
         jsc: {
           target,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -901,3 +901,21 @@ test('generate sourcemap with --treeshake', async () => {
       }),
   )
 })
+
+test('include sourceRoot in sourcemap with --sourceRoot', async () => {
+  const { getFileContent } = await run(
+    getTestName(),
+    {
+      'input.ts': `export const hi = 'hi'`,
+    },
+    {
+      entry: ['input.ts'],
+      flags: ['--sourcemap', '--sourceRoot=/'],
+    },
+  )
+  const sourceMap = await getFileContent(`dist/input.js.map`).then(
+    (rawContent) => JSON.parse(rawContent),
+  )
+
+  expect(sourceMap.sourceRoot).toBe('/')
+})


### PR DESCRIPTION
Add `sourceRoot` option, which is delegated to [esbuild's option](https://esbuild.github.io/api/#source-root).