### PR TITLE
feat: add support for async `injectStyle`

### DIFF
--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -9,7 +9,7 @@ export const postcssPlugin = ({
   cssLoader,
 }: {
   css?: Map<string, string>
-  inject?: boolean | ((css: string, fileId: string) => Promise<string>)
+  inject?: boolean | ((css: string, fileId: string) => string | Promise<string>)
   cssLoader?: Loader
 }): Plugin => {
   return {
@@ -122,12 +122,11 @@ export const postcssPlugin = ({
             })
           ).code
 
-          contents =
-            typeof inject === 'function'
-              ? await inject(JSON.stringify(contents), args.path)
-              : `import styleInject from '#style-inject';styleInject(${JSON.stringify(
-                  contents,
-                )})`
+          contents = typeof inject === 'function'
+            ? await Promise.resolve(inject(JSON.stringify(contents), args.path))
+            : `import styleInject from '#style-inject';styleInject(${JSON.stringify(
+                contents,
+              )})`
 
           return {
             contents,

--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -9,7 +9,7 @@ export const postcssPlugin = ({
   cssLoader,
 }: {
   css?: Map<string, string>
-  inject?: boolean | ((css: string, fileId: string) => string)
+  inject?: boolean | ((css: string, fileId: string) => Promise<string>)
   cssLoader?: Loader
 }): Plugin => {
   return {
@@ -124,7 +124,7 @@ export const postcssPlugin = ({
 
           contents =
             typeof inject === 'function'
-              ? inject(JSON.stringify(contents), args.path)
+              ? await inject(JSON.stringify(contents), args.path)
               : `import styleInject from '#style-inject';styleInject(${JSON.stringify(
                   contents,
                 )})`

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,7 @@ export async function build(_options: Options) {
                 configName: item?.name,
                 options: {
                   ...options, // functions cannot be cloned
+                  injectStyle: typeof options.injectStyle === 'function' ? undefined : options.injectStyle,
                   banner: undefined,
                   footer: undefined,
                   esbuildPlugins: undefined,

--- a/src/options.ts
+++ b/src/options.ts
@@ -210,7 +210,7 @@ export type Options = {
    * Inject CSS as style tags to document head
    * @default {false}
    */
-  injectStyle?: boolean | ((css: string, fileId: string) => Promise<string>)
+  injectStyle?: boolean | ((css: string, fileId: string) => string | Promise<string>)
   /**
    * Inject cjs and esm shims if needed
    * @default false

--- a/src/options.ts
+++ b/src/options.ts
@@ -210,7 +210,7 @@ export type Options = {
    * Inject CSS as style tags to document head
    * @default {false}
    */
-  injectStyle?: boolean | ((css: string, fileId: string) => string)
+  injectStyle?: boolean | ((css: string, fileId: string) => Promise<string>)
   /**
    * Inject cjs and esm shims if needed
    * @default false


### PR DESCRIPTION
This PR adds support for an asynchronous `injectStyle` function. 

It also fixes #1194 

We faced an issue where we needed to run custom PostCSS processing in the `injectStyle` function, and certain PostCSS plugins only work in async mode.

Would appreciate a merge, so we can move back to using the `tsup` rather than a fork :)