### PR TITLE
fix: fix `experimentalDts` file cleaning and watching

### DIFF
--- a/src/api-extractor.ts
+++ b/src/api-extractor.ts
@@ -136,9 +136,9 @@ async function rollupDtsFiles(
   }
 }
 
-function cleanDtsFiles(options: NormalizedOptions) {
+async function cleanDtsFiles(options: NormalizedOptions) {
   if (options.clean) {
-    removeFiles(['**/*.d.{ts,mts,cts}'], options.outDir)
+    await removeFiles(['**/*.d.{ts,mts,cts}'], options.outDir)
   }
 }
 
@@ -156,7 +156,7 @@ export async function runDtsRollup(
     if (!exports) {
       throw new Error('Unexpected internal error: dts exports is not define')
     }
-    cleanDtsFiles(options)
+    await cleanDtsFiles(options)
     for (const format of options.format) {
       await rollupDtsFiles(options, exports, format)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,13 @@ export async function build(_options: Options) {
           logger.info('CLI', 'Running in watch mode')
         }
 
+        const experimentalDtsTask = async () => {
+          if (!options.dts && options.experimentalDts) {
+            const exports = runTypeScriptCompiler(options);
+            await runDtsRollup(options, exports);
+          }
+        }
+
         const dtsTask = async () => {
           if (options.dts && options.experimentalDts) {
             throw new Error(
@@ -214,10 +221,7 @@ export async function build(_options: Options) {
             )
           }
 
-          if (options.experimentalDts) {
-            const exports = runTypeScriptCompiler(options)
-            await runDtsRollup(options, exports)
-          }
+          experimentalDtsTask();
 
           if (options.dts) {
             await new Promise<void>((resolve, reject) => {
@@ -351,6 +355,8 @@ export async function build(_options: Options) {
                 }),
               ])
 
+              experimentalDtsTask()
+              
               if (options.onSuccess) {
                 if (typeof options.onSuccess === 'function') {
                   onSuccessCleanup = await options.onSuccess()


### PR DESCRIPTION
Fixed several issues related to `experimentalDts`:
1. Fixed the output type files pointed to non-existent files when `experimentalDts: true` (https://github.com/egoist/tsup/issues/1050)
2. Fixed the DTS files were only generated once when `experimentalDts: true` (https://github.com/egoist/tsup/issues/970#issuecomment-1959545483)