### PR TITLE
refactor: remove unnecessary promise wrapper

### DIFF
--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -124,9 +124,7 @@ export const postcssPlugin = ({
 
           contents =
             typeof inject === 'function'
-              ? await Promise.resolve(
-                  inject(JSON.stringify(contents), args.path),
-                )
+              ? await inject(JSON.stringify(contents), args.path)
               : `import styleInject from '#style-inject';styleInject(${JSON.stringify(
                   contents,
                 )})`


### PR DESCRIPTION
The `await` will automatically handle the following expression, whether a promise or not. 
So there is no need to wrap it with `Promise.resolve` ❤️

> - Non-thenable value: An already-fulfilled Promise is constructed and used.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#description