### PR TITLE
cleanup: replace `execa` with `tinyexec`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playground
 .idea
 .DS_Store
 .eslintcache
+.pnpm-store

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "consola": "^3.2.3",
     "debug": "^4.3.7",
     "esbuild": "^0.23.1",
-    "execa": "^5.1.1",
     "joycon": "^3.1.1",
     "picocolors": "^1.1.0",
     "postcss-load-config": "^6.0.1",
@@ -66,6 +65,7 @@
     "rollup": "^4.21.3",
     "source-map": "0.8.0-beta.0",
     "sucrase": "^3.35.0",
+    "tinyexec": "^0.3.0",
     "tinyglobby": "^0.2.6",
     "tree-kill": "^1.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
-      execa:
-        specifier: ^5.1.1
-        version: 5.1.1
       joycon:
         specifier: ^3.1.1
         version: 3.1.1
@@ -50,6 +47,9 @@ importers:
       sucrase:
         specifier: ^3.35.0
         version: 3.35.0
+      tinyexec:
+        specifier: ^0.3.0
+        version: 0.3.0
       tinyglobby:
         specifier: ^0.2.6
         version: 0.2.6

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { Worker } from 'node:worker_threads'
 import { loadTsConfig } from 'bundle-require'
-import execa from 'execa'
+import { x } from 'tinyexec'
 import { glob } from 'tinyglobby'
 import kill from 'tree-kill'
 import { version } from '../package.json'
@@ -365,11 +365,13 @@ export async function build(_options: Options) {
                 if (typeof options.onSuccess === 'function') {
                   onSuccessCleanup = await options.onSuccess()
                 } else {
-                  onSuccessProcess = execa(options.onSuccess, {
-                    shell: true,
-                    stdio: 'inherit',
-                  })
-                  onSuccessProcess.on('exit', (code) => {
+                  onSuccessProcess = x(options.onSuccess, [], {
+                    nodeOptions: {
+                      shell: true,
+                      stdio: 'inherit',
+                    },
+                  }).process
+                  onSuccessProcess?.on('exit', (code) => {
                     if (code && code !== 0) {
                       process.exitCode = code
                     }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { expect } from 'vitest'
-import execa from 'execa'
 import fs from 'fs-extra'
+import { x } from 'tinyexec'
 import { glob } from 'tinyglobby'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -43,16 +43,12 @@ export async function run(
   const entry = options.entry || ['input.ts']
 
   // Run tsup cli
-  const { exitCode, stdout, stderr } = await execa(
-    bin,
-    [...entry, ...(options.flags || [])],
-    {
-      cwd: testDir,
-      env: { ...process.env, ...options.env },
-    },
-  )
+  const result = x(bin, [...entry, ...(options.flags || [])], {
+    nodeOptions: { cwd: testDir, env: { ...process.env, ...options.env } },
+  })
+  const { stdout, stderr } = await result
   const logs = stdout + stderr
-  if (exitCode !== 0) {
+  if (result.exitCode !== 0) {
     throw new Error(logs)
   }
 

--- a/vitest-global.ts
+++ b/vitest-global.ts
@@ -1,12 +1,12 @@
 import path from 'node:path'
 import fs from 'node:fs/promises'
-import execa from 'execa'
+import { x } from 'tinyexec'
 
 export default async function setup() {
   const testDir = path.resolve(__dirname, 'test')
   const cacheDir = path.resolve(testDir, '.cache')
   await fs.rm(cacheDir, { recursive: true, force: true })
   console.log(`Installing dependencies in ./test folder`)
-  await execa('pnpm', ['i'], { cwd: testDir })
+  await x('pnpm', ['i'], { nodeOptions: { cwd: testDir } })
   console.log(`Done... start testing..`)
 }


### PR DESCRIPTION
This PR is a suggestion to replace heavier `execa` with lighter `tinyexec`.