### PR TITLE
chore: remove duplicated renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["config:base"]
-}


### PR DESCRIPTION
A new renovate config `.github/renovate.json5` has been added in https://github.com/egoist/tsup/commit/668241895594e656a2cf02babea314bd1256ab89, so this old one `renovate.json` should be removed. It seems that currently, renovate.json is being picked up, which is preventing Renovate PRs from being grouped.