### PR TITLE
docs: add notes for `--env` flag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -354,7 +354,7 @@ You can use `--env` flag to define compile-time environment variables:
 tsup src/index.ts --env.NODE_ENV production
 ```
 
-Note that `--env.VAR_NAME` only recognizes `process.env.VAR_NAME` and `import.meta.env.VAR_NAME`.
+Note that `--env.VAR_NAME` only recognizes `process.env.VAR_NAME` and `import.meta.env.VAR_NAME`. If you use `process.env`, it will only take effect when it is used as a built-in global variable. Therefore, do not import `process` from `node:process`.
 
 ### Building CLI app
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -354,6 +354,8 @@ You can use `--env` flag to define compile-time environment variables:
 tsup src/index.ts --env.NODE_ENV production
 ```
 
+Note that `--env.VAR_NAME` only recognizes `process.env.VAR_NAME` and `import.meta.env.VAR_NAME`.
+
 ### Building CLI app
 
 When an entry file like `src/cli.ts` contains hashbang like `#!/bin/env node` tsup will automatically make the output file executable, so you don't have to run `chmod +x dist/cli.js`.


### PR DESCRIPTION
ESLint asked me to do `import process from 'node:process'`, and then it took me an hour to realize this feature :(