### PR TITLE
fix: change `newlineKind` to `lf` for `experimentalDts`

### DIFF
--- a/src/api-extractor.ts
+++ b/src/api-extractor.ts
@@ -49,6 +49,7 @@ function rollupDtsFile(
       tsconfigFilePath,
     },
     projectFolder: cwd,
+    newlineKind: 'lf',
   }
   const prepareOptions: IExtractorConfigPrepareOptions = {
     configObject,


### PR DESCRIPTION
## **This PR**:

- [X] Changes `@microsoft/api-extractor`'s `newlineKind` option from the default `crlf` to `lf`.