### PR TITLE
fix: run `experimentalDts` only once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ export async function build(_options: Options) {
             )
           }
 
-          experimentalDtsTask()
+          await experimentalDtsTask()
 
           if (options.dts) {
             await new Promise<void>((resolve, reject) => {
@@ -345,8 +345,6 @@ export async function build(_options: Options) {
                   })
                 }),
               ])
-
-              experimentalDtsTask()
 
               if (options.onSuccess) {
                 if (typeof options.onSuccess === 'function') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -322,7 +322,7 @@ const convertArrayEntriesToObjectEntries = (arrayOfEntries: string[]) => {
 /**
  * Resolves and standardizes entry paths into an object format. If the provided
  * entry is a string or an array of strings, it resolves any potential glob
- * patterns amd converts the result into an entry object. If the input is
+ * patterns and converts the result into an entry object. If the input is
  * already an object, it is returned as-is.
  *
  * @example


### PR DESCRIPTION
## **This PR**:

- [X] Removes duplicate function call of `experimentalDtsTask` which resulted in `experimentalDts` running twice.