### PR TITLE
onSuccess & Watch Fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,8 +353,6 @@ export async function build(_options: Options) {
                   onSuccessProcess = exec(options.onSuccess, [], {
                     nodeOptions: { shell: true, stdio: 'inherit' },
                   })
-
-                  await onSuccessProcess
                   if (
                     onSuccessProcess.exitCode &&
                     onSuccessProcess.exitCode !== 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,12 +353,15 @@ export async function build(_options: Options) {
                   onSuccessProcess = exec(options.onSuccess, [], {
                     nodeOptions: { shell: true, stdio: 'inherit' },
                   })
-                  if (
-                    onSuccessProcess.exitCode &&
-                    onSuccessProcess.exitCode !== 0
-                  ) {
-                    process.exitCode = onSuccessProcess.exitCode
+
+                  const processExitHandler = async () => {
+                    const result = await onSuccessProcess
+
+                    if (result?.exitCode && result?.exitCode !== 0) {
+                      process.exitCode = result.exitCode
+                    }
                   }
+                  processExitHandler()
                 }
               }
             }


### PR DESCRIPTION
fixes https://github.com/egoist/tsup/issues/1245

Removed an await line for tinyexec-based binary executation command.
Watch commands would not trigger if an onSuccess command was provided.