### PR TITLE
fix watching when the onSuccess process never exits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,14 +353,11 @@ export async function build(_options: Options) {
                   onSuccessProcess = exec(options.onSuccess, [], {
                     nodeOptions: { shell: true, stdio: 'inherit' },
                   })
-
-                  await onSuccessProcess
-                  if (
-                    onSuccessProcess.exitCode &&
-                    onSuccessProcess.exitCode !== 0
-                  ) {
-                    process.exitCode = onSuccessProcess.exitCode
-                  }
+                  onSuccessProcess.process?.on('exit', (code) => {
+                    if (code && code !== 0) {
+                      process.exitCode = code
+                    }
+                  })
                 }
               }
             }


### PR DESCRIPTION
fixes #1245

it restores the original behaviour we had while using execa.

The bug was introduced in https://github.com/egoist/tsup/commit/4dd5bfeb2f1973242e2f9700a3061aee9d8af988#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80