### PR TITLE
Add IIFE external notice

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,8 @@ This will output `dist/index.js` and `dist/cli.js`.
 
 By default tsup bundles all `import`-ed modules but `dependencies` and `peerDependencies` in your `package.json` are always excluded, you can also use `--external <module|pkgJson>` flag to mark other packages or other special `package.json`'s `dependencies` and `peerDependencies` as external.
 
+**IMPORTANT**: IIFE output is not supported with `--external` option.
+
 ### Excluding all packages
 
 If you are using **tsup** to build for **Node.js** applications/APIs, usually bundling dependencies is not needed, and it can even break things, for instance, while outputting to [ESM](https://nodejs.org/api/esm.html).


### PR DESCRIPTION
I spend near a day to understand why i see `ERROR: Could not resolve`, when a mark as external all imports except entry points with `^(?!index\.ts$).*` regexp. Just add a notice, that is not supported.

I found that is the source code of tsup, so i can prove it just not works with IIFE output.

https://github.com/egoist/tsup/blob/main/src/esbuild/index.ts#L134
```typescript
format !== 'iife' &&
      externalPlugin({
        external,
        noExternal: options.noExternal,
        skipNodeModulesBundle: options.skipNodeModulesBundle,
        tsconfigResolvePaths: options.tsconfigResolvePaths,
      }),
```

---

I copy-pasted plugin, and import `bundle-require` and it works.