### PR TITLE
feat: added option to allow alternative postcss file extensions

### DIFF
--- a/src/esbuild/index.ts
+++ b/src/esbuild/index.ts
@@ -144,6 +144,7 @@ export async function runEsbuild(
       css,
       inject: options.injectStyle,
       cssLoader: loader['.css'],
+      fileExtensions: options.postcssFileExtensions
     }),
     sveltePlugin({ css }),
     ...(options.esbuildPlugins || []),

--- a/src/esbuild/postcss.ts
+++ b/src/esbuild/postcss.ts
@@ -7,10 +7,12 @@ export const postcssPlugin = ({
   css,
   inject,
   cssLoader,
+  fileExtensions = ["css"]
 }: {
   css?: Map<string, string>
   inject?: boolean | ((css: string, fileId: string) => string | Promise<string>)
-  cssLoader?: Loader
+  cssLoader?: Loader,
+  fileExtensions?: string[]
 }): Plugin => {
   return {
     name: 'postcss',
@@ -77,7 +79,7 @@ export const postcssPlugin = ({
         },
       )
 
-      build.onLoad({ filter: /\.css$/ }, async (args) => {
+      build.onLoad({ filter: new RegExp(fileExtensions.map(ext => `\\.${ext}$`).join("|")) }, async (args) => {
         let contents: string
 
         if (css && args.path.endsWith('.svelte.css')) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -220,6 +220,11 @@ export type Options = {
     | boolean
     | ((css: string, fileId: string) => string | Promise<string>)
   /**
+   * Allowed postcss file extensions
+   * @default ["css"]
+   */
+  postcssFileExtensions?: string[]
+  /**
    * Inject cjs and esm shims if needed
    * @default false
    */

--- a/test/__snapshots__/css.test.ts.snap
+++ b/test/__snapshots__/css.test.ts.snap
@@ -10,6 +10,11 @@ exports[`import css in --dts 1`] = `
 "
 `;
 
+exports[`support alternative postcss file extension 1`] = `
+""use strict";
+"
+`;
+
 exports[`support tailwindcss postcss plugin 1`] = `
 ""use strict";
 "


### PR DESCRIPTION
While migrating a project to using tsup I needed a way to run the postcss plugin on files with different file extensions than `.css`, unfortunately it was not an option to change the file extensions on all postcss files in this project. I added an option to allow running the postcss plugin on alternative file extensions.