### PR TITLE
fix(deps): upgrading node for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     // Update 'VARIANT' to pick a Node version: 16, 14, 12.
     // Append -bullseye or -buster to pin to an OS version.
     // Use -bullseye variants on local arm64/Apple Silicon.
-    "args": { "VARIANT": "16-bullseye" }
+    "args": { "VARIANT": "18-bullseye" }
   },
 
   // Set *default* container specific settings.json values on container create.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playground
 .idea
 .DS_Store
 .eslintcache
+.pnpm-store


### PR DESCRIPTION
Node 16 is deprecated. pnpm requires 18
Also updating .gitignore when using devcontainer