### PR TITLE
feat: use `fix-dts-default-cjs-exports` to transform CJS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "consola": "^3.4.0",
     "debug": "^4.4.0",
     "esbuild": "^0.25.0",
+    "fix-dts-default-cjs-exports": "^1.0.0",
     "joycon": "^3.1.1",
     "picocolors": "^1.1.1",
     "postcss-load-config": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.0
+      fix-dts-default-cjs-exports:
+        specifier: ^1.0.0
+        version: 1.0.0
       joycon:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1073,6 +1076,9 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  fix-dts-default-cjs-exports@1.0.0:
+    resolution: {integrity: sha512-i9Vd++WOWo6JilNgZvNvmy1T0r+/j7vikghQSEhKIuDwz4GjUrYj+Z18zlL7MleYNxE+xE6t3aG7LiAwA1P+dg==}
 
   flat@6.0.1:
     resolution: {integrity: sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==}
@@ -2532,6 +2538,12 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
     optional: true
+
+  fix-dts-default-cjs-exports@1.0.0:
+    dependencies:
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      rollup: 4.34.8
 
   flat@6.0.1: {}
 

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -11,6 +11,7 @@ import { getProductionDeps, loadPkg } from './load'
 import { reportSize } from './lib/report-size'
 import type { NormalizedOptions } from './'
 import type { InputOptions, OutputOptions, Plugin } from 'rollup'
+import { FixDtsDefaultCjsExportsPlugin } from 'fix-dts-default-cjs-exports/rollup'
 
 const logger = createLogger()
 
@@ -89,25 +90,6 @@ const getRollupConfig = async (
     },
   }
 
-  const fixCjsExport: Plugin = {
-    name: 'tsup:fix-cjs-export',
-    renderChunk(code, info) {
-      if (
-        info.type !== 'chunk' ||
-        !/\.(ts|cts)$/.test(info.fileName) ||
-        !info.isEntry ||
-        info.exports?.length !== 1 ||
-        info.exports[0] !== 'default'
-      )
-        return
-
-      return code.replace(
-        /(?<=(?<=[;}]|^)\s*export\s*){\s*([\w$]+)\s*as\s+default\s*}/,
-        `= $1`,
-      )
-    },
-  }
-
   return {
     inputConfig: {
       input: dtsOptions.entry,
@@ -167,7 +149,7 @@ const getRollupConfig = async (
         entryFileNames: `[name]${outputExtension}`,
         chunkFileNames: `[name]-[hash]${outputExtension}`,
         plugins: [
-          format === 'cjs' && options.cjsInterop && fixCjsExport,
+          format === 'cjs' && options.cjsInterop && FixDtsDefaultCjsExportsPlugin(),
         ].filter(Boolean),
       }
     }),


### PR DESCRIPTION
I extracted from this [unbuild]https://github.com/unjs/unbuild/pull/475] PR the logic to fix default CJS exports to this repository [fix-dts-default-cjs-exports](https://github.com/userquin/fix-dts-default-cjs-exports). 

This PR using the Rollup plugin from the new repository replacing the current plugin here. Here [unbuild]() PR to use the same Rollup plugin.

Looks like tsup, unbuild and pkgroll using rollup-plugin-dts.
