### PR TITLE
fix: copyPublicDir in watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -346,6 +346,8 @@ export async function build(_options: Options) {
                 }),
               ])
 
+              copyPublicDir(options.publicDir, options.outDir)
+
               if (options.onSuccess) {
                 if (typeof options.onSuccess === 'function') {
                   onSuccessCleanup = await options.onSuccess()
@@ -445,7 +447,6 @@ export async function build(_options: Options) {
             logger.info('CLI', `Target: ${options.target}`)
 
             await buildAll()
-            copyPublicDir(options.publicDir, options.outDir)
 
             startWatcher()
           }


### PR DESCRIPTION
This PR fixes [#831](https://github.com/egoist/tsup/issues/831) by moving the `copyPublicDir` call inside the `buildAll` function. As a result, files from the public directory are now also copied when `debouncedBuildAll` is triggered (e.g., in watch mode).

### This introduces a **potential breaking change**:

Before:
- if `onSuccess` was a function, it was always called before `copyPublicDir` was even invoked.
- if `onSuccess` was a string, both the copy and the shell command were started simultaneously, leading to race conditions. In most cases, the copy finished first, but behavior was unreliable

After this change:
- `onSuccess` is always called after `copyPublicDir` completes — ensuring the build (including public files) is fully ready before executing any post-build logic.


### Potential improvements:
- optimize by running `copyPublicDir` inside `debouncedBuildAll` only when options.clean is true. However, this may not be worth the added complexity: most public directories are probably small and `debouncedBuildAll` is already throttled. The current implementation is simpler and more predictable, which may outweigh this optimization.
- tests (requires test for watch mode)