### PR TITLE
fix: incorrect `configDir` variable resolution in tsconfig.json

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -20,7 +20,7 @@ const parseCompilerOptions = (compilerOptions?: any) => {
   const { options } = ts.parseJsonConfigFileContent(
     { compilerOptions },
     ts.sys,
-    './',
+    path.resolve('./'),
   )
   return options
 }


### PR DESCRIPTION
This PR solves #1347 by passing the absolute path to the `basePath` argument of `parseJsonConfigFileContent`. Without this, `${configDir}` seems to resolve to the empty string `''` rendering the feature unusable.

As far as I can tell this shouldn't affect the typescript configurations that don't use `configDir`.