### PR TITLE
Fix file watching

### DIFF
--- a/assets/cjs_shims.js
+++ b/assets/cjs_shims.js
@@ -3,11 +3,12 @@
 // if we export it as `const importMetaUrl = ... __filename ...`
 // But using a function will not cause this issue
 
-const getImportMetaUrl = () => 
-  typeof document === "undefined" 
-    ? new URL(`file:${__filename}`).href 
-    : (document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT') 
-      ? document.currentScript.src 
-      : new URL("main.js", document.baseURI).href;
+const getImportMetaUrl = () =>
+  typeof document === 'undefined'
+    ? new URL(`file:${__filename}`).href
+    : document.currentScript &&
+        document.currentScript.tagName.toUpperCase() === 'SCRIPT'
+      ? document.currentScript.src
+      : new URL('main.js', document.baseURI).href
 
 export const importMetaUrl = /* @__PURE__ */ getImportMetaUrl()

--- a/docs/README.md
+++ b/docs/README.md
@@ -615,6 +615,7 @@ When you use legacy TypeScript decorator by enabling `emitDecoratorMetadata` in 
 decorators. In this case, you can give extra swc configuration in the `tsup.config.ts` file.
 
 For example, if you have to define `useDefineForClassFields`, you can do that as follows:
+
 ```ts
 import { defineConfig } from 'tsup'
 
@@ -626,10 +627,10 @@ export default defineConfig({
   swc: {
     jsc: {
       transform: {
-        useDefineForClassFields: true
-      }
-    }
-  }
+        useDefineForClassFields: true,
+      },
+    },
+  },
 })
 ```
 
@@ -648,9 +649,9 @@ Note: some SWC options cannot be configured:
   "keepClassNames": true,
   "target": "es2022"
 }
- ```
+```
 
-You can also define a custom `.swcrc` configuration file. Just set `swcrc` to `true` 
+You can also define a custom `.swcrc` configuration file. Just set `swcrc` to `true`
 in `tsup.config.ts` to allow SWC plugin to discover automatically your custom swc config file.
 
 ```ts
@@ -662,8 +663,8 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   swc: {
-    swcrc: true
-  }
+    swcrc: true,
+  },
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "debug": "^4.4.0",
     "esbuild": "^0.27.0",
     "fix-dts-default-cjs-exports": "^1.0.0",
+    "glob-to-regex.js": "^1.2.0",
     "joycon": "^3.1.1",
     "picocolors": "^1.1.1",
     "postcss-load-config": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       fix-dts-default-cjs-exports:
         specifier: ^1.0.0
         version: 1.0.1
+      glob-to-regex.js:
+        specifier: ^1.2.0
+        version: 1.2.0(tslib@2.8.1)
       joycon:
         specifier: ^3.1.1
         version: 3.1.1
@@ -1298,6 +1301,12 @@ packages:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
 
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
@@ -1774,6 +1783,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsup@8.3.6:
     resolution: {integrity: sha512-XkVtlDV/58S9Ye0JxUUTcrQk4S+EqlOHKzg6Roa62rdjL1nGWNUstG0xgI4vanHdfIpjP448J8vlN0oK6XOJ5g==}
@@ -2866,6 +2878,10 @@ snapshots:
       nypm: 0.6.2
       pathe: 2.0.3
 
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   glob@10.4.5:
     dependencies:
       foreground-child: 3.3.1
@@ -3291,6 +3307,8 @@ snapshots:
       typescript: 5.7.3
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
 
   tsup@8.3.6(@microsoft/api-extractor@7.55.0(@types/node@22.13.4))(@swc/core@1.10.18)(jiti@2.6.1)(postcss@8.5.2)(typescript@5.7.3)(yaml@2.8.1):
     dependencies:

--- a/src/esbuild/swc.ts
+++ b/src/esbuild/swc.ts
@@ -9,7 +9,10 @@ import type { Logger } from '../log'
 
 export type SwcPluginConfig = { logger: Logger } & Options
 
-export const swcPlugin = ({ logger, ...swcOptions }: SwcPluginConfig): Plugin => {
+export const swcPlugin = ({
+  logger,
+  ...swcOptions
+}: SwcPluginConfig): Plugin => {
   return {
     name: 'swc',
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import fs from 'node:fs'
 import { Worker } from 'node:worker_threads'
 import { loadTsConfig } from 'bundle-require'
 import { exec, type Result as ExecChild } from 'tinyexec'
-import { glob, globSync } from 'tinyglobby'
+import { glob } from 'tinyglobby'
+import { toMatcher } from 'glob-to-regex.js'
 import kill from 'tree-kill'
 import { version } from '../package.json'
 import { PrettyError, handleError } from './errors'
@@ -406,7 +407,7 @@ export async function build(_options: Options) {
               const watcher = watch(await glob(watchPaths), {
                 ignoreInitial: true,
                 ignorePermissionErrors: true,
-                ignored: (p) => globSync(p, { ignore: ignored }).length === 0,
+                ignored: toMatcher(ignored),
               })
               watcher.on('all', async (type, file) => {
                 file = slash(file)

--- a/src/options.ts
+++ b/src/options.ts
@@ -257,8 +257,8 @@ export type Options = {
    * @default true
    */
   removeNodeProtocol?: boolean
-  
-  swc?: SwcPluginConfig;
+
+  swc?: SwcPluginConfig
 }
 
 export interface NormalizedExperimentalDtsConfig {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     testTimeout: 50000,
     globalSetup: 'vitest-global.ts',
-    include: ["test/*.test.ts", "src/**/*.test.ts"]
+    include: ['test/*.test.ts', 'src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
The performance of using tinyglobby to figure out ignores was just way too slow as it gets queried for every single file under the working directory including `node_modules`, replace with a glob-to-regex.js which is just a regex check with no file system access and/or .gitignore parsing which is not needed here

Hopefully fixes #1293 and others