### PR TITLE
Fix compatibility with TypeScript 6 or 7

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -112,7 +112,6 @@ const getRollupConfig = async (
           tsconfig: options.tsconfig,
           compilerOptions: {
             ...compilerOptions,
-            baseUrl: compilerOptions.baseUrl || '.',
             // Ensure ".d.ts" modules are generated
             declaration: true,
             // Skip ".js" generation


### PR DESCRIPTION
Fixes:
https://github.com/egoist/tsup/issues/1389
https://github.com/egoist/tsup/issues/1388

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

Tested as a monkey patch here:

https://github.com/pxseu/fami/commit/08c396dcc81a0b1ab7e6bba8420b45ecc9af22a1
https://github.com/pxseu/fami/actions/runs/23560643308/job/68599308721#step:5:9