### PR TITLE
fix: preserve `with` import attributes when treeshaking

### DIFF
--- a/src/plugins/tree-shaking.ts
+++ b/src/plugins/tree-shaking.ts
@@ -48,6 +48,9 @@ export const treeShakingPlugin = ({
         file: info.path,
         sourcemap: !!this.options.sourcemap,
         compact: !!this.options.minify,
+        // Preserve modern `with` import attributes instead of rewriting them to
+        // the deprecated `assert` syntax (Rollup defaults to `assert`).
+        importAttributesKey: 'with',
         name,
       })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -925,3 +925,23 @@ test('generate sourcemap with --treeshake', async () => {
       }),
   )
 })
+
+test('preserve import attributes with --treeshake and bundle: false', async () => {
+  const { outFiles, getFileContent } = await run(
+    getTestName(),
+    {
+      'input.ts': `import data from './data.json' with { type: 'json' }\nexport default data`,
+      'data.json': `{ "hello": "world" }`,
+      'tsup.config.ts': `export default { bundle: false }`,
+    },
+    {
+      entry: ['input.ts'],
+      flags: ['--treeshake', '--target', 'esnext', '--format', 'esm'],
+    },
+  )
+
+  expect(outFiles).toContain('input.mjs')
+  const output = await getFileContent('dist/input.mjs')
+  expect(output).toContain(`with { type: 'json' }`)
+  expect(output).not.toContain('assert')
+})


### PR DESCRIPTION
Closes #1374

## Problem
With `bundle: false` and `treeshake: true`, tsup rewrites modern `import data from './x.json' with { type: 'json' }` into the deprecated `assert { type: 'json' }` syntax, which is a SyntaxError on Node 22+.

## Root cause
`treeshake: true` runs the output through a Rollup `bundle.generate()` pass (`src/plugins/tree-shaking.ts`), whose `OutputOptions` default `importAttributesKey` to `assert`. (The esbuild and `.d.ts` paths are unaffected.)

## Fix
Set `importAttributesKey: 'with'` on the tree-shaking Rollup output so the standard `with` syntax is preserved.

## Test
Added a test that builds with `bundle: false` + `--treeshake`, importing JSON via `with { type: 'json' }`, asserting the output contains `with { type: 'json' }` and not `assert`.