### PR TITLE
fix: resolve browser field in DTS generation for platform: browser

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -105,7 +105,7 @@ const getRollupConfig = async (
       },
       plugins: [
         tsupCleanPlugin,
-        tsResolveOptions && tsResolvePlugin(tsResolveOptions),
+        tsResolveOptions && tsResolvePlugin({...tsResolveOptions, platform: options.platform}),
         jsonPlugin(),
         ignoreFiles,
         dtsPlugin.default({

--- a/src/rollup/ts-resolve.ts
+++ b/src/rollup/ts-resolve.ts
@@ -23,11 +23,14 @@ const resolveModule = (
 export type TsResolveOptions = {
   resolveOnly?: Array<string | RegExp>
   ignore?: (source: string, importer?: string) => boolean
+  /** When 'browser', resolve browser field mappings for DTS generation */
+  platform?: 'node' | 'browser' | 'neutral'
 }
 
 export const tsResolvePlugin: PluginImpl<TsResolveOptions> = ({
   resolveOnly,
   ignore,
+  platform,
 } = {}) => {
   const resolveExtensions = ['.d.ts', '.ts']
 
@@ -95,6 +98,15 @@ export const tsResolvePlugin: PluginImpl<TsResolveOptions> = ({
           basedir,
           extensions: resolveExtensions,
           packageFilter(pkg) {
+            // When platform is browser, resolve the browser field for DTS
+            // This ensures --platform browser + --dts uses the correct type paths
+            if (platform === 'browser' && pkg.browser && typeof pkg.browser === 'object') {
+              const typesPath = pkg.types || pkg.typings
+              if (typesPath && pkg.browser[typesPath]) {
+                pkg.main = pkg.browser[typesPath]
+                return pkg
+              }
+            }
             pkg.main = pkg.types || pkg.typings
             return pkg
           },


### PR DESCRIPTION
## Problem

When using , the generated  files resolve to the non-browser entry point because the DTS rollup resolver ignores the  field in .

For example, a package with:



 correctly bundles , but  generates types from  instead.

## Fix

1. Add  option to  type
2. Pass  to  from 
3. In , when platform is , check the  field mapping for types paths

Fixes #1397